### PR TITLE
New feature: Configurable rules + Rule SourceEqualsTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ N.A.
 
 ## [Prereleases]
 
+## [0.2.1] 10-08-2019
+* Introduced new setting `xliffSync.needWorkTranslationRules` that can be used which checks need to be run by command `XLIFF: Check for Need Work Translations`.
+* Added new rule `SourceEqualsTarget` which checks that the source and target are the same for files where source and target language are the same. (GitHub issue [#18](https://github.com/rvanbekkum/vsc-xliff-sync/issues/18))
+
 ## [0.2.1] 19-07-2019
 * Fixed bug introduced by refactoring in 0.2.0: default shortcuts blocking clipboard. Also, made shortcuts the same for all operating systems.
 * Fixed bug introduced by refactoring in 0.1.6: command `XLIFF: Synchronize to Single File` synchronzing to the wrong file.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This extension is based on the [Angular Localization Helper extension](https://g
 | xliffSync.xliffGeneratorNoteDesignation | `Xliff Generator` | Specifies the name that is used to designate a XLIFF generator note. |
 | xliffSync.autoCheckMissingTranslations | `false` | Specifies whether or not the extension should automatically check for missing translations after syncing. |
 | xliffSync.autoCheckNeedWorkTranslations | `false` | Specifies whether or not the extension should automatically run a technical validation on translations after syncing |
+| xliffSync.needWorkTranslationRules | `["OptionMemberCount", "OptionLeadingSpaces", "Placeholders"]` | Specifies which technical validation rules should be used. |
 | xliffSync.preserveTargetAttributes | `false` | Specifies whether or not syncing should use the attributes from the target files for the trans-unit nodes while syncing. |
 | xliffSync.preserveTargetAttributesOrder | `false` | Specifies whether the attributes of trans-unit nodes should use the order found in the target files while syncing. |
 | xliffSync.decoration | 'Highlight yellow, white border' | Specifies how to highlight missing translations or translations that need work in an XLIFF file opened in the editor. |
@@ -122,13 +123,15 @@ This will run technical validation/checks for all XLIFF files in the workspace a
 
 ![XLIFF Sync Check Need Work Translations Messages](resources/xliffSync_checkNeedWorkTranslations.png)
 
+You can configure the checks that need to be run with the `xliffSync.needWorkTranslationRules` setting.
 The currently implemented checks are the following:
 
-| Check                                                             | Trigger                                   | Example                                                                                                 |
-|-------------------------------------------------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| Placeholders of source and translation are not matching. | Source/Translation text includes placeholders of the form `{0}` or `%1`. | The source text includes placeholders `%1 %2` , but the translation text only includes `%1`. |
-| Number of options in caption are not matching. | Xliff Generator note with `Property OptionCaption` or `Property PromotedActionCategories`. | The source text includes 3 options, `A,B,C` , but the translation text includes 4 options, `A,B,C,D`. |
-| Number of leading spaces in options are not matching. | Xliff Generator note with `Property OptionCaption` or `Property PromotedActionCategories`. | The source text includes a space, `A, B` , but the translation text does not, `A,B`. |
+| Rule ID               | Check                                                                                                     | Trigger                                                                                    | Example                                                                                                            |
+|-----------------------|-----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `OptionMemberCount`   | Number of options in caption are not matching.                                                            | Xliff Generator note with `Property OptionCaption` or `Property PromotedActionCategories`. | The source text includes 3 options, `A,B,C` , but the translation text includes 4 options, `A,B,C,D`.              |
+| `OptionLeadingSpaces` | Number of leading spaces in options are not matching.                                                     | Xliff Generator note with `Property OptionCaption` or `Property PromotedActionCategories`. | The source text includes a space, `A, B` , but the translation text does not, `A,B`.                               |
+| `Placeholders`        | Placeholders of source and translation are not matching.                                                  | Source/Translation text includes placeholders of the form `{0}` or `%1`.                   | The source text includes placeholders `%1 %2` , but the translation text only includes `%1`.                       |
+| `SourceEqualsTarget`  | Source and translation are not the same, even though source-language = target-language for the .xlf file. | The source-language is the same as the target-language for the .xlf file.                  | The source text is 'A', but the translation text is 'B'. The source-language and target-language are both 'en-US'. |
 
 ### Find Next Missing Translation in XLIFF File
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -86,6 +86,31 @@
                     "default" : false,
                     "description": "Specifies whether or not the extension should automatically run a technical validation on translations after syncing"
                 },
+                "xliffSync.needWorkTranslationRules": {
+					"type": "array",
+					"items": {
+                        "type" : "string",
+                        "enum": [
+                            "OptionMemberCount",
+                            "OptionLeadingSpaces",
+                            "Placeholders",
+                            "SourceEqualsTarget"
+                        ],
+                        "enumDescriptions": [
+                            "Checks that the number of members of the OptionCaption or PromotedActionCategories property match.",
+                            "Checks that the leading spaces of members of the OptionCaption or PromotedActionCategories property match.",
+                            "Checks that the number of placeholders match.",
+                            "Checks that the source and target are the same for files where source and target language are the same."
+                        ]
+                    },
+                    "default": [
+                        "OptionMemberCount",
+                        "OptionLeadingSpaces",
+                        "Placeholders"
+                    ],
+					"uniqueItems": true,
+					"description": "Specifies which technical validation rules should be used."
+				},
                 "xliffSync.preserveTargetAttributes": {
                     "type" : "boolean",
                     "default" : false,


### PR DESCRIPTION
You can now configure which technical validation rules should be run by command `XLIFF: Check for Need Work Translations`.
This can be done by the new setting `xliffSync.needWorkTranslationRules` which takes an array with rule IDs that should apply.
For now the allowed values are:
```json
"xliffSync.needWorkTranslationRules": [
    "OptionMemberCount",
    "OptionLeadingSpaces",
    "Placeholders",
    "SourceEqualsTarget"
]
```

This pull request introduces a new `SourceEqualsTarget`, which checks that the source and target are the same for files where source and target language are the same (e.g., when both are set to "en-US" for an .xlf file).
This closes #18.