### PR TITLE
Support for multi-root workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.2.6",
+    "version": "0.3.0",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -43,67 +43,84 @@
                 "xliffSync.baseFile": {
                     "type": "string",
                     "default": "application.g.xlf",
-                    "description": "Specifies the base XLIFF translation file."
+                    "description": "Specifies the base XLIFF translation file.",
+                    "scope": "resource"
                 },
                 "xliffSync.fileType": {
                     "type": "string",
                     "default": "xlf",
-                    "description": "Specifies the translation files' type (xlf, xlf2)."
+                    "description": "Specifies the translation files' type (xlf, xlf2).",
+                    "enum": [
+                        "xlf", 
+                        "xlf2"
+                    ],
+                    "scope": "resource"
                 },
                 "xliffSync.findByXliffGeneratorNoteAndSource": {
                     "type": "boolean",
                     "default": true,
-                    "description" : "Specifies whether or not the extension will try to find translation units by XLIFF generator note and source."
+                    "description" : "Specifies whether or not the extension will try to find translation units by XLIFF generator note and source.",
+                    "scope": "resource"
                 },
                 "xliffSync.findByXliffGeneratorAndDeveloperNote": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Specifies whether or not the extension will try to find translation units by XLIFF generator note and developer note."
+                    "description": "Specifies whether or not the extension will try to find translation units by XLIFF generator note and developer note.",
+                    "scope": "resource"
                 },
                 "xliffSync.findByXliffGeneratorNote": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Specifies whether or not the extension will try to find translation units by XLIFF generator note."
+                    "description": "Specifies whether or not the extension will try to find translation units by XLIFF generator note.",
+                    "scope": "resource"
                 },
                 "xliffSync.findBySourceAndDeveloperNote": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Specifies whether or not the extension will try to find trans-units by source and developer note."
+                    "description": "Specifies whether or not the extension will try to find trans-units by source and developer note.",
+                    "scope": "resource"
                 },
                 "xliffSync.findBySource": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Specifies whether or not the extension will try to find translation units by source."
+                    "description": "Specifies whether or not the extension will try to find translation units by source.",
+                    "scope": "resource"
                 },
                 "xliffSync.copyFromSourceForSameLanguage": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Specifies whether translations should be copied from the source text if source-language = target-language."
+                    "description": "Specifies whether translations should be copied from the source text if source-language = target-language.",
+                    "scope": "resource"
                 },
                 "xliffSync.missingTranslation": {
                     "type": "string",
                     "default": "%EMPTY%",
-                    "description": "Target tag content for missing translation (use %EMPTY% to leave new targets empty)."
+                    "description": "Target tag content for missing translation (use %EMPTY% to leave new targets empty).",
+                    "scope": "resource"
                 },
                 "xliffSync.developerNoteDesignation": {
                     "type" : "string",
                     "default" : "Developer",
-                    "description": "Specifies the name that is used to designate a developer note."
+                    "description": "Specifies the name that is used to designate a developer note.",
+                    "scope": "resource"
                 },
                 "xliffSync.xliffGeneratorNoteDesignation": {
                     "type" : "string",
                     "default" : "Xliff Generator",
-                    "description": "Specifies the name that is used to designate a XLIFF generator note."
+                    "description": "Specifies the name that is used to designate a XLIFF generator note.",
+                    "scope": "resource"
                 },
                 "xliffSync.autoCheckMissingTranslations": {
                     "type" : "boolean",
                     "default" : false,
-                    "description": "Specifies whether or not the extension should automatically check for missing translations after syncing."
+                    "description": "Specifies whether or not the extension should automatically check for missing translations after syncing.",
+                    "scope": "resource"
                 },
                 "xliffSync.autoCheckNeedWorkTranslations": {
                     "type" : "boolean",
                     "default" : false,
-                    "description": "Specifies whether or not the extension should automatically run a technical validation on translations after syncing."
+                    "description": "Specifies whether or not the extension should automatically run a technical validation on translations after syncing.",
+                    "scope": "resource"
                 },
                 "xliffSync.needWorkTranslationRules": {
 					"type": "array",
@@ -128,22 +145,26 @@
                         "Placeholders"
                     ],
 					"uniqueItems": true,
-					"description": "Specifies which technical validation rules should be used."
+                    "description": "Specifies which technical validation rules should be used.",
+                    "scope": "resource"
 				},
                 "xliffSync.preserveTargetAttributes": {
                     "type" : "boolean",
                     "default" : false,
-                    "description": "Specifies whether or not syncing should use the attributes from the target files for the trans-unit nodes while syncing."
+                    "description": "Specifies whether or not syncing should use the attributes from the target files for the trans-unit nodes while syncing.",
+                    "scope": "resource"
                 },
                 "xliffSync.preserveTargetAttributesOrder": {
                     "type" : "boolean",
                     "default" : false,
-                    "description": "Specifies whether the attributes of trans-unit nodes should use the order found in the target files while syncing."
+                    "description": "Specifies whether the attributes of trans-unit nodes should use the order found in the target files while syncing.",
+                    "scope": "resource"
                 },
                 "xliffSync.replaceTranslationsDuringImport": {
                     "type": "boolean",
                     "default" : false,
-                    "description": "Specifies whether existing translations will be replaced when the XLIFF: Import Translations from File(s) command is run."
+                    "description": "Specifies whether existing translations will be replaced when the XLIFF: Import Translations from File(s) command is run.",
+                    "scope": "resource"
                 },
                 "xliffSync.decoration": {
                     "type": "object",

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -28,14 +28,17 @@ import {
   TextEditor,
   Uri,
   window,
-  workspace
+  workspace,
+  WorkspaceFolder,
+  RelativePattern
 } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 
 export class FilesHelper {
-  public static async findTranslationFiles(fileExt: string): Promise<Uri[]> {
-    return workspace.findFiles(`**/*.${fileExt}`).then((files) =>
+  public static async findTranslationFiles(workspaceFolder: WorkspaceFolder, fileExt: string): Promise<Uri[]> {
+    let relativePattern: RelativePattern = new RelativePattern(workspaceFolder, `**/*.${fileExt}`);
+    return workspace.findFiles(relativePattern).then((files) =>
       files.sort((a, b) => {
         if (a.fsPath.length !== b.fsPath.length) {
           return a.fsPath.length - b.fsPath.length;

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -3,3 +3,4 @@ export * from './xml-node';
 export * from './xml-parser';
 export * from './xlf-translator';
 export * from './files-helper';
+export * from './workspace-helper';

--- a/src/features/tools/workspace-helper.ts
+++ b/src/features/tools/workspace-helper.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Rob van Bekkum
+ *
+ * Licensed under the MIT license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { workspace, WorkspaceFolder, window } from "vscode";
+
+export class WorkspaceHelper {
+    public static async getWorkspaceFolders(allFiles: boolean): Promise<WorkspaceFolder[] | undefined> {
+        let currentWorkspaceFolder: WorkspaceFolder | undefined = window.activeTextEditor ?
+            workspace.getWorkspaceFolder(window.activeTextEditor.document.uri) :
+            undefined;
+        let syncWorkspaceFolders: WorkspaceFolder[] | undefined = currentWorkspaceFolder ?
+            [currentWorkspaceFolder] :
+            workspace.workspaceFolders;
+    
+        if (!allFiles && !currentWorkspaceFolder && syncWorkspaceFolders) {
+            currentWorkspaceFolder = await window.showWorkspaceFolderPick({
+              placeHolder: 'Select a workspace folder' 
+            });
+            syncWorkspaceFolders = undefined;
+            if (currentWorkspaceFolder) {
+                syncWorkspaceFolders = [currentWorkspaceFolder];
+            }
+        }
+    
+        return syncWorkspaceFolders;
+      }
+}

--- a/src/features/tools/workspace-helper.ts
+++ b/src/features/tools/workspace-helper.ts
@@ -32,7 +32,7 @@ export class WorkspaceHelper {
             [currentWorkspaceFolder] :
             workspace.workspaceFolders;
     
-        if (!allFiles && !currentWorkspaceFolder && syncWorkspaceFolders) {
+        if (!allFiles && !currentWorkspaceFolder && syncWorkspaceFolders && syncWorkspaceFolders.length > 1) {
             currentWorkspaceFolder = await window.showWorkspaceFolderPick({
               placeHolder: 'Select a workspace folder' 
             });

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -22,16 +22,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { workspace, WorkspaceConfiguration } from 'vscode';
+import { workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
 import { XlfDocument } from './xlf/xlf-document';
 
 export class XlfTranslator {
   public static async synchronize(
+    workspaceFolder: WorkspaceFolder,
     source: string,
     target: string | undefined,
     targetLanguage: string | undefined,
   ): Promise<string | undefined> {
-    const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync');
+    const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', workspaceFolder.uri);
     const findByXliffGeneratorNoteAndSource: boolean = xliffWorkspaceConfiguration['findByXliffGeneratorNoteAndSource'];
     const findByXliffGeneratorAndDeveloperNote: boolean = xliffWorkspaceConfiguration['findByXliffGeneratorAndDeveloperNote'];
     const findByXliffGeneratorNote: boolean = xliffWorkspaceConfiguration['findByXliffGeneratorNote'];
@@ -40,7 +41,7 @@ export class XlfTranslator {
     const copyFromSourceForSameLanguage: boolean = xliffWorkspaceConfiguration['copyFromSourceForSameLanguage'];
     let copyFromSource: boolean = false;
 
-    const mergedDocument = await XlfDocument.load(source);
+    const mergedDocument = await XlfDocument.load(workspaceFolder.uri, source);
 
     if (!mergedDocument || !mergedDocument.valid) {
       return undefined;
@@ -51,8 +52,8 @@ export class XlfTranslator {
     }
 
     const targetDocument = target
-      ? await XlfDocument.load(target)
-      : XlfDocument.create(<'1.2' | '2.0'>mergedDocument.version, targetLanguage!);
+      ? await XlfDocument.load(workspaceFolder.uri, target)
+      : XlfDocument.create(workspaceFolder.uri, <'1.2' | '2.0'>mergedDocument.version, targetLanguage!);
     const language = targetDocument.targetLanguage;
 
     if (language) {

--- a/src/features/trans-sync.ts
+++ b/src/features/trans-sync.ts
@@ -86,7 +86,7 @@ export async function getXliffFileUrisInWorkSpace(): Promise<Uri[]> {
     }
 
     if (!uris.length) {
-        fileType = await window.showQuickPick(['xlf', 'xmb'], {
+        fileType = await window.showQuickPick(['xlf', 'xlf2'], {
             placeHolder: 'Translation file type',
         });
 


### PR DESCRIPTION
This pull request introduces support for multi-root workspaces.
You can have settings per workspace folder, each with their _own_ base XLIFF file.
The commands "XLIFF: Synchronize Translation Units", "XLIFF: Check for Missing Translations" and "XLIFF: Check for Need Work Translations" will run for each project folder in the workspace, but if a file from a specific project is opened, then the commands will run for the specific project folder only.
The command "XLIFF: Synchronize to Single File" will run for either the open file, or will prompt the user to select a workspace folder first. If there is only a single workspace folder, then it will not ask the user to select one.