### PR TITLE
Default value for basefile setting to .g.xlf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.4] 12-01-2019
+
+* Changed default value for setting `xliffSync.baseFile` to `.g.xlf` (GitHub issue [#34](https://github.com/rvanbekkum/vsc-xliff-sync/issues/34))
+
 ## [0.3.3] 16-11-2019
 
 * Added notification that shows that an XLIFF Sync is in progress. This notification includes the name of the target file for which a sync is in progress.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 
 | Setting | Default | Explanation |
 | ------- | ------- | ----------- |
-| xliffSync.baseFile | `application.g.xlf` | Specifies which XLIFF file to use as the base (e.g., the generated XLIFF). If the file does not exist, you will be prompted to specify the file to use as base-XLIFF file the first time you use the Synchronize command. |
+| xliffSync.baseFile | `.g.xlf` | Specifies which XLIFF file to use as the base (e.g., the generated XLIFF). If the file does not exist, you will be prompted to specify the file to use as base-XLIFF file the first time you use the Synchronize command. |
 | xliffSync.fileType | `xlf` | The file type (`xlf` or `xlf2`). |
 | xliffSync.missingTranslation | `%EMPTY%` | The placeholder for missing translations for trans-units that were synced/merged into target XLIFF files. You can use `%EMPTY%` if you want to use an empty string for missing translations. |
 | xliffSync.findByXliffGeneratorNoteAndSource | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and source. |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -42,7 +42,7 @@
             "properties": {
                 "xliffSync.baseFile": {
                     "type": "string",
-                    "default": "application.g.xlf",
+                    "default": ".g.xlf",
                     "description": "Specifies the base XLIFF translation file.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
Change the default for the `xliffSync.baseFile` setting to `g.xlf`.
Updates to the CHANGELOG and README accordingly.

Please see issue #34.