### PR TITLE
Decoration Optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xliff-sync",
-  "version": "0.1.3",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -34,6 +34,7 @@
     "activationEvents": [
         "onCommand:xliffSync.synchronizeFile",
         "workspaceContains:**/*.xlf",
+        "workspaceContains:**/*.xlf2",
         "onCommand:xliffSync.findNextMissingTarget"
     ],
     "contributes": {
@@ -51,7 +52,7 @@
                     "default": "xlf",
                     "description": "Specifies the translation files' type (xlf, xlf2).",
                     "enum": [
-                        "xlf", 
+                        "xlf",
                         "xlf2"
                     ],
                     "scope": "resource"
@@ -59,7 +60,7 @@
                 "xliffSync.findByXliffGeneratorNoteAndSource": {
                     "type": "boolean",
                     "default": true,
-                    "description" : "Specifies whether or not the extension will try to find translation units by XLIFF generator note and source.",
+                    "description": "Specifies whether or not the extension will try to find translation units by XLIFF generator note and source.",
                     "scope": "resource"
                 },
                 "xliffSync.findByXliffGeneratorAndDeveloperNote": {
@@ -111,33 +112,33 @@
                     "scope": "resource"
                 },
                 "xliffSync.developerNoteDesignation": {
-                    "type" : "string",
-                    "default" : "Developer",
+                    "type": "string",
+                    "default": "Developer",
                     "description": "Specifies the name that is used to designate a developer note.",
                     "scope": "resource"
                 },
                 "xliffSync.xliffGeneratorNoteDesignation": {
-                    "type" : "string",
-                    "default" : "Xliff Generator",
+                    "type": "string",
+                    "default": "Xliff Generator",
                     "description": "Specifies the name that is used to designate a XLIFF generator note.",
                     "scope": "resource"
                 },
                 "xliffSync.autoCheckMissingTranslations": {
-                    "type" : "boolean",
-                    "default" : false,
+                    "type": "boolean",
+                    "default": false,
                     "description": "Specifies whether or not the extension should automatically check for missing translations after syncing.",
                     "scope": "resource"
                 },
                 "xliffSync.autoCheckNeedWorkTranslations": {
-                    "type" : "boolean",
-                    "default" : false,
+                    "type": "boolean",
+                    "default": false,
                     "description": "Specifies whether or not the extension should automatically run a technical validation on translations after syncing.",
                     "scope": "resource"
                 },
                 "xliffSync.needWorkTranslationRules": {
-					"type": "array",
-					"items": {
-                        "type" : "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
                         "enum": [
                             "ConsecutiveSpacesConsistent",
                             "ConsecutiveSpacesExist",
@@ -162,31 +163,31 @@
                         "OptionLeadingSpaces",
                         "Placeholders"
                     ],
-					"uniqueItems": true,
+                    "uniqueItems": true,
                     "description": "Specifies which technical validation rules should be used.",
                     "scope": "resource"
                 },
                 "xliffSync.needWorkTranslationRulesEnableAll": {
-                    "type" : "boolean",
-                    "default" : false,
+                    "type": "boolean",
+                    "default": false,
                     "description": "Specifies whether or not all available technical validation rules should be used. Enabling this setting makes xliffSync.needWorkTranslationRules redundant.",
                     "scope": "resource"
                 },
                 "xliffSync.preserveTargetAttributes": {
-                    "type" : "boolean",
-                    "default" : false,
+                    "type": "boolean",
+                    "default": false,
                     "description": "Specifies whether or not syncing should use the attributes from the target files for the trans-unit nodes while syncing.",
                     "scope": "resource"
                 },
                 "xliffSync.preserveTargetAttributesOrder": {
-                    "type" : "boolean",
-                    "default" : false,
+                    "type": "boolean",
+                    "default": false,
                     "description": "Specifies whether the attributes of trans-unit nodes should use the order found in the target files while syncing.",
                     "scope": "resource"
                 },
                 "xliffSync.replaceTranslationsDuringImport": {
                     "type": "boolean",
-                    "default" : false,
+                    "default": false,
                     "description": "Specifies whether existing translations will be replaced when the XLIFF: Import Translations from File(s) command is run.",
                     "scope": "resource"
                 },
@@ -194,6 +195,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Specifies whether decorations for missing translations and translations that need work should be applied."
+                },
+                "xliffSync.decorationTargetTextOnly": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether decorations for missing translations and translations that need work should only be applied to the target text."
                 },
                 "xliffSync.decoration": {
                     "type": "object",

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -108,4 +108,8 @@ export class FilesHelper {
   public static getFileNameFromUri(fileUri: Uri): string {
     return fileUri.toString().replace(/^.*[\\\/]/, '').replace(/%20/g, ' ');
   }
+
+  public static getSupportedFileExtensions(): string[] {
+    return ['xlf', 'xlf2'];
+  }
 }


### PR DESCRIPTION
* Only apply decorations in XLIFF files (not in every editor)
* Reload settings (i.e., `"xliffSync.decoration"`, `"xliffSync.decorationEnabled"`, `"xliffSync.decorationTargetTextOnly"`, `"xliffSync.missingTranslation"`) when switching active editor
* Add new setting `"xliffSync.decorationTargetTextOnly"` to have decorations only be applied to the target node's text, if enabled.
* Change highlight-update interval from 1 to 500 (ms)

Closes #39 