### PR TITLE
DetectSourceTextChanges and IgnoreLineEndingTypeChanges Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [0.3.6] 28-02-2019
+## [0.3.7] 18-05-2020
+
+* New setting `xliffSync.detectSourceTextChanges` (see README)
+* New setting `xliffSync.detectSourceTextChanges` (GitHub issue [#41](https://github.com/rvanbekkum/vsc-xliff-sync/issues/41))
+
+## [0.3.6] 28-02-2020
 
 * Only apply decorations in XLIFF files (not in every editor) (GitHub issue [#39](https://github.com/rvanbekkum/vsc-xliff-sync/issues/39))
 * Reload settings (i.e., `"xliffSync.decoration"`, `"xliffSync.decorationEnabled"`, `"xliffSync.decorationTargetTextOnly"`, `"xliffSync.missingTranslation"`) when switching active editor
@@ -11,12 +16,12 @@
 
 * **[GregoryAA](https://github.com/GregoryAA)** for reporting the issues with decorations. (GitHub issue [#39](https://github.com/rvanbekkum/vsc-xliff-sync/issues/39))
 
-## [0.3.5] 25-02-2019
+## [0.3.5] 25-02-2020
 
 * Added new setting `xliffSync.parseFromDeveloperNote` (default: false) to have translations parsed from the Developer note if no matching trans-units or translations can be found. Translations can be retrieved from a Developer note in the following format: `en-US=My translation|nl-NL=Mijn vertaling` (GitHub issue [#37](https://github.com/rvanbekkum/vsc-xliff-sync/issues/37)).
 * Added new setting `xliffSync.parseFromDeveloperNoteSeparator` (default: `|`) accompanying setting `xliffSync.parseFromDeveloperNote` to change the separator for translations.
 
-## [0.3.4] 12-01-2019
+## [0.3.4] 12-01-2020
 
 * Changed default value for setting `xliffSync.baseFile` to `.g.xlf` (GitHub issue [#34](https://github.com/rvanbekkum/vsc-xliff-sync/issues/34)).
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.parseFromDeveloperNote | `false` | "Specifies whether translations should be parsed from the developer note. Translations can be retrieved from a Developer note in the following format: `en-US=My translation|nl-NL=Mijn vertaling`. |
 | xliffSync.parseFromDeveloperNoteSeparator | `|` | Specifies the separator that is used when translations are parsed from the developer note. |
 | xliffSync.copyFromSourceForSameLanguage | `false` | Specifies whether translations should be copied from the source text if source-language = target-language. This will **not** overwrite existing translations of trans-units in target files. |
+| xliffSync.detectSourceTextChanges | `true` | Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed. |
+| xliffSync.ignoreLineEndingTypeChanges | `false` | Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit. |
 | xliffSync.developerNoteDesignation | `Developer` | Specifies the name that is used to designate a developer note. |
 | xliffSync.xliffGeneratorNoteDesignation | `Xliff Generator` | Specifies the name that is used to designate a XLIFF generator note. |
 | xliffSync.autoCheckMissingTranslations | `false` | Specifies whether or not the extension should automatically check for missing translations after syncing. |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -172,6 +172,11 @@
                     "default": false,
                     "description": "Specifies whether or not all available technical validation rules should be used. Enabling this setting makes xliffSync.needWorkTranslationRules redundant.",
                     "scope": "resource"
+                },
+                "xliffSync.ignoreLineEndingTypeChanges": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit."
                 },
                 "xliffSync.preserveTargetAttributes": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -173,10 +173,17 @@
                     "description": "Specifies whether or not all available technical validation rules should be used. Enabling this setting makes xliffSync.needWorkTranslationRules redundant.",
                     "scope": "resource"
                 },
+                "xliffSync.detectSourceTextChanges": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed.",
+                    "scope": "resource"
+                },
                 "xliffSync.ignoreLineEndingTypeChanges": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit."
+                    "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.",
+                    "scope": "resource"
                 },
                 "xliffSync.preserveTargetAttributes": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,18 @@
                     "description": "Specifies whether translations should be copied from the source text if source-language = target-language.",
                     "scope": "resource"
                 },
+                "xliffSync.detectSourceTextChanges": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed.",
+                    "scope": "resource"
+                },
+                "xliffSync.ignoreLineEndingTypeChanges": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.",
+                    "scope": "resource"
+                },
                 "xliffSync.missingTranslation": {
                     "type": "string",
                     "default": "%EMPTY%",
@@ -171,18 +183,6 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Specifies whether or not all available technical validation rules should be used. Enabling this setting makes xliffSync.needWorkTranslationRules redundant.",
-                    "scope": "resource"
-                },
-                "xliffSync.detectSourceTextChanges": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed.",
-                    "scope": "resource"
-                },
-                "xliffSync.ignoreLineEndingTypeChanges": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.",
                     "scope": "resource"
                 },
                 "xliffSync.preserveTargetAttributes": {

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -38,6 +38,7 @@ export class XlfTranslator {
     const findByXliffGeneratorNote: boolean = xliffWorkspaceConfiguration['findByXliffGeneratorNote'];
     const findBySourceAndDeveloperNote: boolean = xliffWorkspaceConfiguration['findBySourceAndDeveloperNote'];
     const findBySource: boolean = xliffWorkspaceConfiguration['findBySource'];
+    const ignoreLineEndingTypeChanges: boolean = xliffWorkspaceConfiguration['ignoreLineEndingTypeChanges'];
     const copyFromSourceForSameLanguage: boolean = xliffWorkspaceConfiguration['copyFromSourceForSameLanguage'];
     const parseFromDeveloperNote: boolean = xliffWorkspaceConfiguration['parseFromDeveloperNote'];
     let copyFromSource: boolean = false;
@@ -126,12 +127,20 @@ export class XlfTranslator {
       mergedDocument.mergeUnit(unit, targetUnit, translation);
 
       if (targetUnit) {
-        const mergedSourceText = mergedDocument.getUnitSourceText(unit);
+        let mergedSourceText = mergedDocument.getUnitSourceText(unit);
         const mergedTranslText = mergedDocument.getUnitTranslation(unit);
-        const origSourceText = targetDocument.getUnitSourceText(targetUnit);
-        if (mergedSourceText && origSourceText && mergedTranslText && mergedSourceText !== origSourceText) {
-          mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
-          mergedDocument.setTargetAttribute(unit, 'state', 'needs-adaptation');
+        let origSourceText = targetDocument.getUnitSourceText(targetUnit);
+
+        if (mergedSourceText && origSourceText && mergedTranslText) {
+          if (ignoreLineEndingTypeChanges) {
+            mergedSourceText = mergedSourceText.replace(/\r\n/g, "\n");
+            origSourceText = origSourceText.replace(/\r\n/g, "\n");
+          }
+
+          if (mergedSourceText !== origSourceText) {
+            mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
+            mergedDocument.setTargetAttribute(unit, 'state', 'needs-adaptation');
+          }
         }
       }
     });

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -38,9 +38,10 @@ export class XlfTranslator {
     const findByXliffGeneratorNote: boolean = xliffWorkspaceConfiguration['findByXliffGeneratorNote'];
     const findBySourceAndDeveloperNote: boolean = xliffWorkspaceConfiguration['findBySourceAndDeveloperNote'];
     const findBySource: boolean = xliffWorkspaceConfiguration['findBySource'];
-    const ignoreLineEndingTypeChanges: boolean = xliffWorkspaceConfiguration['ignoreLineEndingTypeChanges'];
     const copyFromSourceForSameLanguage: boolean = xliffWorkspaceConfiguration['copyFromSourceForSameLanguage'];
     const parseFromDeveloperNote: boolean = xliffWorkspaceConfiguration['parseFromDeveloperNote'];
+    const detectSourceTextChanges: boolean = xliffWorkspaceConfiguration['detectSourceTextChanges'];
+    const ignoreLineEndingTypeChanges: boolean = xliffWorkspaceConfiguration['ignoreLineEndingTypeChanges'];
     let copyFromSource: boolean = false;
 
     const mergedDocument = await XlfDocument.load(workspaceFolder.uri, source);
@@ -126,7 +127,7 @@ export class XlfTranslator {
 
       mergedDocument.mergeUnit(unit, targetUnit, translation);
 
-      if (targetUnit) {
+      if (detectSourceTextChanges && targetUnit) {
         let mergedSourceText = mergedDocument.getUnitSourceText(unit);
         const mergedTranslText = mergedDocument.getUnitTranslation(unit);
         let origSourceText = targetDocument.getUnitSourceText(targetUnit);


### PR DESCRIPTION
This PR adds the following new options:
* `xliffSync.detectSourceTextChanges` - Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed.
* `xliffSync.ignoreLineEndingTypeChanges` - Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.

Updated README and CHANGELOG accordingly.

Resolves issue #41.