### PR TITLE
Parse from Developer Note Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.8] 31-05-2020
+
+* New setting `xliffSync.parseFromDeveloperNoteOverwrite` which when enabled will overwrite existing translations with the translations parsed from the Developer Note.
+* New setting `xliffSync.copyFromSourceOverwrite` which when enabled will overwrite existing translations with the source text.
+* The "Parse from Developer Note" feature will now also update translations if `xliffSync.missingTranslation` is configured to something other than the default value (which is missing translation = no translation).
+* XLIFF Sync snippets for the "Parse from Developer Note" feature.
+  * You can configure for which programming languages the snippets should be available with setting `xliffSync.enableSnippetsForLanguages`. Currently only the "AL Language" is supported with snippets: `tcaptionwithtranslation`, `tcommentwithtranslation`, `toptioncaptionwithtranslation`, `tpromotedactioncategorieswithtranslation`, `tlabelwithtranslation` and `ttooltipwithtranslation` snippets.
+  * You can configure a default target language that should be used by the snippets with setting `xliffSync.snippetTargetLanguage`.
+
 ## [0.3.7] 18-05-2020
 
 * New setting `xliffSync.detectSourceTextChanges` (see README)

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.findBySourceAndDeveloperNote | `false` | Specifies whether or not the extension will try to find translations by the combination of source and developer note. |
 | xliffSync.findBySource | `false` | Specifies whether or not the extension will try to find translations by source. If there are multiple trans-units with the same source, then the translation of the first translation unit is used for all units. |
 | xliffSync.parseFromDeveloperNote | `false` | Specifies whether translations should be parsed from the developer note. Translations can be retrieved from a Developer note in the following format: <code>en-US=My translation&#124;nl-NL=Mijn vertaling</code>. |
+| xliffSync.parseFromDeveloperNoteOverwrite | `false` | Specifies whether translations parsed from the developer note should always overwrite existing translations. |
 | xliffSync.parseFromDeveloperNoteSeparator | <code>&#124;</code> | Specifies the separator that is used when translations are parsed from the developer note. |
 | xliffSync.copyFromSourceForLanguages | `[]` | Specifies the languages for which translations should be copied from the source text of trans-units. |
 | xliffSync.copyFromSourceForSameLanguage | `false` | Specifies whether translations should be copied from the source text if source-language = target-language. This will **not** overwrite existing translations of trans-units in target files. |
+| xliffSync.copyFromSourceOverwrite | `false` | Specifies whether translations copied from the source text should overwrite existing translations. |
 | xliffSync.detectSourceTextChanges | `true` | Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed. |
 | xliffSync.ignoreLineEndingTypeChanges | `false` | Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit. |
 | xliffSync.developerNoteDesignation | `Developer` | Specifies the name that is used to designate a developer note. |
@@ -82,6 +84,8 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.decoration | `{"backgroundColor": "rgba(240, 210, 105, 0.35)", "overviewRulerColor": "rgba(240, 210, 105, 0.35)", "border": "1px solid white", "borderRadius": "4px"}` | Specifies how to highlight missing translations or translations that need work in an XLIFF file opened in the editor. |
 | xliffSync.decorationEnabled | `true` | Specifies whether decorations for missing translations and translations that need work should be applied. |
 | xliffSync.decorationTargetTextOnly | `false` | Specifies whether decorations for missing translations and translations that need work should only be applied to the target text. |
+| xliffSync.enableSnippetsForLanguages | `[]` | Specifies the programming languages for which the XLIFF Sync snippets should be enabled. Currently supported: `al`. |
+| xliffSync.snippetTargetLanguage | `TargetLanguageCode` | Specifies which target language to use by default in the XLIFF Sync snippets (e.g., `nl-NL`). |
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -93,6 +93,12 @@
                     "description": "Specifies whether translations should be parsed from the developer note.",
                     "scope": "resource"
                 },
+                "xliffSync.parseFromDeveloperNoteOverwrite": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether translations parsed from the developer note should always overwrite existing translations.",
+                    "scope": "resource"
+                },
                 "xliffSync.parseFromDeveloperNoteSeparator": {
                     "type": "string",
                     "default": "|",
@@ -113,6 +119,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Specifies whether translations should be copied from the source text if source-language = target-language.",
+                    "scope": "resource"
+                },
+                "xliffSync.copyFromSourceOverwrite": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether translations copied from the source text should overwrite existing translations.",
                     "scope": "resource"
                 },
                 "xliffSync.detectSourceTextChanges": {

--- a/package.json
+++ b/package.json
@@ -244,6 +244,29 @@
                         "borderRadius": "4px"
                     },
                     "description": "Decoration for missing translations and translations that need work."
+                },
+                "xliffSync.enableSnippetsForLanguages": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "al"
+                        ],
+                        "enumDescriptions": [
+                            "AL"
+                        ]
+                    },
+                    "default": [
+                    ],
+                    "uniqueItems": true,
+                    "description": "Specifies the programming languages for which the XLIFF Sync snippets should be enabled.",
+                    "scope": "resource"
+                },
+                "xliffSync.snippetTargetLanguage": {
+                    "type": "string",
+                    "default": "TargetLanguageCode",
+                    "description": "Specifies which target language to use by default in the XLIFF Sync snippets.",
+                    "scope": "resource"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import {
     ExtensionContext
 } from 'vscode';
 
+import { registerSnippets } from './features/snippets';
 import { synchronizeFiles, synchronizeWithSelectedFile, createNewTargetFiles } from './features/trans-sync';
 import { XliffTranslationChecker } from './features/trans-check';
 import { XliffTranslationImport } from './features/trans-import';
@@ -33,6 +34,8 @@ export function activate(context: ExtensionContext) {
             }
         })
     );
+
+    registerSnippets();
 }
 
 export function deactivate() {

--- a/src/features/snippets.ts
+++ b/src/features/snippets.ts
@@ -1,0 +1,77 @@
+import { CompletionItemKind, languages, SnippetString, window, workspace, WorkspaceConfiguration, commands } from "vscode";
+
+export async function registerSnippets() {
+    const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync');
+    const enableSnippetsForLanguages: string[] = xliffWorkspaceConfiguration['enableSnippetsForLanguages'];
+    const snippetTargetLanguage: string = xliffWorkspaceConfiguration['snippetTargetLanguage'];
+    workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration('xliffSync.enableSnippetsForLanguages') || e.affectsConfiguration('xliffSync.snippetTargetLanguage')) {
+            window.showInformationMessage('The XLIFF Sync snippet settings were changed. Please reload VSCode to apply the changes.', 'Reload').then(selection => {
+                if (selection === 'Reload') {
+                    commands.executeCommand('workbench.action.reloadWindow');
+                }
+            });
+        }
+    });
+
+    if (enableSnippetsForLanguages.indexOf('al') > -1) {
+        registerALSnippets(snippetTargetLanguage);
+    }
+}
+
+function registerALSnippets(snippetTargetLanguage: string) {
+    languages.registerCompletionItemProvider('al', {
+        provideCompletionItems(doc, pos, token, context) {
+            return [
+                {
+                    label: "tcaptionwithtranslation",
+                    insertText: new SnippetString(
+                        `Caption = '\${1:CaptionText}', Comment = '\${2:${snippetTargetLanguage}}=\${3:Translation}';`
+                    ),
+                    detail: "Snippet (XLIFF Sync): Caption with Comment-Translation",
+                    kind: CompletionItemKind.Snippet
+                },
+                {
+                    label: "tcommentwithtranslation",
+                    insertText: new SnippetString(
+                        `Comment = '\${1:${snippetTargetLanguage}}=\${2:Translation}'`
+                    ),
+                    detail: "Snippet (XLIFF Sync): Comment with Translation",
+                    kind: CompletionItemKind.Snippet
+                },
+                {
+                    label: "toptioncaptionwithtranslation",
+                    insertText: new SnippetString(
+                        `OptionCaption = '\${1:OptionCaptionText}', Comment = '\${2:${snippetTargetLanguage}}=\${3:Translation}';`
+                    ),
+                    detail: "Snippet (XLIFF Sync): OptionCaption with Comment-Translation",
+                    kind: CompletionItemKind.Snippet
+                },
+                {
+                    label: "tpromotedactioncategorieswithtranslation",
+                    insertText: new SnippetString(
+                        `PromotedActionCategories = '\${1:PromotedActionCategoriesText}', Comment = '\${2:${snippetTargetLanguage}}=\${3:Translation}';`
+                    ),
+                    detail: "Snippet (XLIFF Sync): PromotedActionCategories with Comment-Translation",
+                    kind: CompletionItemKind.Snippet
+                },
+                {
+                    label: "tlabelwithtranslation",
+                    insertText: new SnippetString(
+                        `\${1:LabelName}: Label '\${2:LabelText}', Comment = '\${3:${snippetTargetLanguage}}=\${4:Translation}';`
+                    ),
+                    detail: "Snippet (XLIFF Sync): Label with Comment-Translation",
+                    kind: CompletionItemKind.Snippet
+                },
+                {
+                    label: "ttooltipwithtranslation",
+                    insertText: new SnippetString(
+                        `ToolTip = '\${1:ToolTipText}', Comment = '\${2:${snippetTargetLanguage}}=\${3:Translation}';`
+                    ),
+                    detail: "Snippet (XLIFF Sync): ToolTip with Comment-Translation",
+                    kind: CompletionItemKind.Snippet
+                },
+            ];
+        }
+    });
+}


### PR DESCRIPTION
* New setting `xliffSync.parseFromDeveloperNoteOverwrite` which when enabled will overwrite existing translations with the translations parsed from the Developer Note.
* New setting `xliffSync.copyFromSourceOverwrite` which when enabled will overwrite existing translations with the source text.
* The "Parse from Developer Note" feature will now also update translations if `xliffSync.missingTranslation` is configured to something other than the default value (which is missing translation = no translation).
* XLIFF Sync snippets for the "Parse from Developer Note" feature.
  * You can configure for which programming languages the snippets should be available with setting `xliffSync.enableSnippetsForLanguages`. Currently only the "AL Language" is supported with snippets: `tcaptionwithtranslation`, `tcommentwithtranslation`, `toptioncaptionwithtranslation`, `tpromotedactioncategorieswithtranslation`, `tlabelwithtranslation` and `ttooltipwithtranslation` snippets.
  * You can configure a default target language that should be used by the snippets with setting `xliffSync.snippetTargetLanguage`.

Resolves issue #43.