### PR TITLE
Improved XLIFF 2.0 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   * `state` attribute on `segment` nodes instead of target nodes.
   * `state` and `subState` used:
     * `needs-translation` -> `initial` with no sub-state
-    * `needs-adapatation` -> `translated` with sub-state configurable with setting `xliffSync.needsWorkTranslationSubstate`.
+    * `needs-adaptation` -> `translated` with sub-state configurable with setting `xliffSync.needsWorkTranslationSubstate`.
     * `translated` -> `translated` with no sub-state.
   * Let `xliffSync.fileType` = `xlf2` work with file-extension `xlf`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
     * `translated` -> `translated` with no sub-state.
   * Let `xliffSync.fileType` = `xlf2` work with file-extension `xlf`.
 
+### Thank You
+
+* **[antpyykk](https://github.com/antpyykk)** for filing the issue with states for XLIFF 2.0 files (GitHub issue [#50](https://github.com/rvanbekkum/vsc-xliff-sync/issues/50))
+
 ## [0.4.0] 02-08-2020
 
 * New setting `xliffSync.syncCrossWorkspaceFolders` which can be used to set that the extension should synchronize from one single base file (`xliffSync.baseFile`) to the translation files in all workspace folders (**Default**: `false`) (GitHub issue [#48](https://github.com/rvanbekkum/vsc-xliff-sync/issues/48)).
@@ -27,6 +31,10 @@
 * XLIFF Sync snippets for the "Parse from Developer Note" feature.
   * You can configure for which programming languages the snippets should be available with setting `xliffSync.enableSnippetsForLanguages`. Currently only the "AL Language" is supported with snippets: `tcaptionwithtranslation`, `tcommentwithtranslation`, `toptioncaptionwithtranslation`, `tpromotedactioncategorieswithtranslation`, `tlabelwithtranslation` and `ttooltipwithtranslation` snippets.
   * You can configure a default target language that should be used by the snippets with setting `xliffSync.snippetTargetLanguage`.
+
+### Thank You
+
+* **[GregoryAA](https://github.com/GregoryAA)** for requesting the _Parse from Developer Note_ feature enhancements. (GitHub issue [#43](https://github.com/rvanbekkum/vsc-xliff-sync/issues/43))
 
 ## [0.3.7] 18-05-2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
     * `needs-adaptation` -> `translated` with sub-state configurable with setting `xliffSync.needsWorkTranslationSubstate`.
     * `translated` -> `translated` with no sub-state.
   * Let `xliffSync.fileType` = `xlf2` work with file-extension `xlf`.
+  * Fix: function `findXliffSyncNoteIndex` should check for the "category" attribute instead of the "from" attribute.
+  * Fix: function `tryDeleteXliffSyncNote` should call `findXliffSyncNoteIndex` with `notesParent` as argument instead of `unit`.
+  * Fix: function `setXliffSyncNote` should only add a new `notes` node in XLIFF 2.0 files if it does not exist for a unit.
+  * Fix: function `setXliffSyncNote` should call `findXliffSyncNoteIndex` to check if an XLIFF Sync note already exists.
+  * "Check for Need Work Translations" now considers the `xliffSync.needsWorkTranslationSubstate` substate.
 
 ### Thank You
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.5.0]
+## [0.5.0] 08-08-2020
 
 * Better XLIFF 2.0 support:
   * `state` attribute on `segment` nodes instead of target nodes.
@@ -13,7 +13,8 @@
   * Fix: function `tryDeleteXliffSyncNote` should call `findXliffSyncNoteIndex` with `notesParent` as argument instead of `unit`.
   * Fix: function `setXliffSyncNote` should only add a new `notes` node in XLIFF 2.0 files if it does not exist for a unit.
   * Fix: function `setXliffSyncNote` should call `findXliffSyncNoteIndex` to check if an XLIFF Sync note already exists.
-  * "Check for Need Work Translations" now considers the `xliffSync.needsWorkTranslationSubstate` substate.
+  * "Check for Need Work Translations" now considers the `xliffSync.needsWorkTranslationSubstate` sub-state.
+  * Decoration is now also applied on `segment` nodes with the `xliffSync.needsWorkTranslationSubstate` sub-state.
 
 ### Thank You
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.0]
+
+* Better XLIFF 2.0 support:
+  * `state` attribute on `segment` nodes instead of target nodes.
+  * `state` and `subState` used:
+    * `needs-translation` -> `initial` with no sub-state
+    * `needs-adapatation` -> `translated` with sub-state configurable with setting `xliffSync.needsWorkTranslationSubstate`.
+    * `translated` -> `translated` with no sub-state.
+  * Let `xliffSync.fileType` = `xlf2` work with file-extension `xlf`.
+
 ## [0.4.0] 02-08-2020
 
 * New setting `xliffSync.syncCrossWorkspaceFolders` which can be used to set that the extension should synchronize from one single base file (`xliffSync.baseFile`) to the translation files in all workspace folders (**Default**: `false`) (GitHub issue [#48](https://github.com/rvanbekkum/vsc-xliff-sync/issues/48)).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.fileType | `xlf` | The file type (`xlf` or `xlf2`). |
 | xliffSync.syncCrossWorkspaceFolders | `false` | Specifies whether the extension will sync from a base file to the translation files in all workspace folders. By default, the extension will always sync. per workspace folder. If you enable this setting, then you can have the base file in one workspace folder and target translation files in other workspace folders. |
 | xliffSync.missingTranslation | `%EMPTY%` | The placeholder for missing translations for trans-units that were synced/merged into target XLIFF files. You can use `%EMPTY%` if you want to use an empty string for missing translations. |
+| xliffSync.needsWorkTranslationSubstate | `poedit:fuzzy`| Specifies the substate to use for translations that need work in xlf2 files. |
 | xliffSync.findByXliffGeneratorNoteAndSource | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and source. |
 | xliffSync.findByXliffGeneratorAndDeveloperNote | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and developer note. |
 | xliffSync.findByXliffGeneratorNote | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note. |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.fileType | `xlf` | The file type (`xlf` or `xlf2`). |
 | xliffSync.syncCrossWorkspaceFolders | `false` | Specifies whether the extension will sync from a base file to the translation files in all workspace folders. By default, the extension will always sync. per workspace folder. If you enable this setting, then you can have the base file in one workspace folder and target translation files in other workspace folders. |
 | xliffSync.missingTranslation | `%EMPTY%` | The placeholder for missing translations for trans-units that were synced/merged into target XLIFF files. You can use `%EMPTY%` if you want to use an empty string for missing translations. |
-| xliffSync.needsWorkTranslationSubstate | `poedit:fuzzy`| Specifies the substate to use for translations that need work in xlf2 files. |
+| xliffSync.needsWorkTranslationSubstate | `xliffSync:needsWork` | Specifies the substate to use for translations that need work in xlf2 files. **Tip**: If you use [Poedit](https://poedit.net/), then you could also set this to `poedit:fuzzy`. |
 | xliffSync.findByXliffGeneratorNoteAndSource | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and source. |
 | xliffSync.findByXliffGeneratorAndDeveloperNote | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and developer note. |
 | xliffSync.findByXliffGeneratorNote | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note. |

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
                 },
                 "xliffSync.needsWorkTranslationSubstate": {
                     "type": "string",
-                    "default": "poedit:fuzzy",
+                    "default": "xliffSync:needsWork",
                     "description": "Specifies the substate to use for translations that need work in xlf2 files.",
                     "scope": "resource"
                 },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -149,6 +149,12 @@
                     "type": "string",
                     "default": "%EMPTY%",
                     "description": "Target tag content for missing translation (use %EMPTY% to leave new targets empty).",
+                    "scope": "resource"
+                },
+                "xliffSync.needsWorkTranslationSubstate": {
+                    "type": "string",
+                    "default": "poedit:fuzzy",
+                    "description": "Specifies the substate to use for translations that need work in xlf2 files.",
                     "scope": "resource"
                 },
                 "xliffSync.developerNoteDesignation": {

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -130,16 +130,16 @@ export class FilesHelper {
     return sourceUri;
   }
 
-  public static async findTranslationFiles(fileExt: string, workspaceFolder?: WorkspaceFolder): Promise<Uri[]> {
+  public static async findTranslationFiles(fileType: string, workspaceFolder?: WorkspaceFolder): Promise<Uri[]> {
     if (workspaceFolder) {
-      return await FilesHelper.findTranslationFilesInWorkspaceFolder(fileExt, workspaceFolder);
+      return await FilesHelper.findTranslationFilesInWorkspaceFolder(fileType, workspaceFolder);
     }
     else {
       let allFileUris: Uri[] = [];
       const workspaceFolders: WorkspaceFolder[] | undefined = await WorkspaceHelper.getWorkspaceFolders(true);
       if (workspaceFolders) {
         for (let wsFolder of workspaceFolders) {
-          let folderFileUris: Uri[] = await FilesHelper.findTranslationFilesInWorkspaceFolder(fileExt, wsFolder);
+          let folderFileUris: Uri[] = await FilesHelper.findTranslationFilesInWorkspaceFolder(fileType, wsFolder);
           allFileUris = allFileUris.concat(folderFileUris);
         }
       }
@@ -147,7 +147,9 @@ export class FilesHelper {
     }
   }
 
-  public static async findTranslationFilesInWorkspaceFolder(fileExt: string, workspaceFolder: WorkspaceFolder): Promise<Uri[]> {
+  public static async findTranslationFilesInWorkspaceFolder(fileType: string, workspaceFolder: WorkspaceFolder): Promise<Uri[]> {
+    const fileExt: string = FilesHelper.getTranslationFileExtensions(fileType);
+
     let relativePattern: RelativePattern = new RelativePattern(workspaceFolder, `**/*.${fileExt}`);
     return workspace.findFiles(relativePattern).then((files) =>
       files.sort((a, b) => {
@@ -157,6 +159,16 @@ export class FilesHelper {
         return a.fsPath.localeCompare(b.fsPath);
       }),
     );
+  }
+
+  public static getTranslationFileExtensions(fileType: string): string {
+    switch(fileType) {
+      case 'xlf':
+        return 'xlf';
+      case 'xlf2':
+        return 'xlf*';
+    }
+    return 'xlf';
   }
 
   public static async createTranslationFile(

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -24,6 +24,7 @@
 
 import { workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
 import { XlfDocument } from './xlf/xlf-document';
+import { translationState } from './xlf/xlf-translationState';
 
 export class XlfTranslator {
   public static async synchronize(
@@ -160,7 +161,7 @@ export class XlfTranslator {
 
           if (mergedSourceText !== origSourceText) {
             mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
-            mergedDocument.setTargetAttribute(unit, 'state', 'needs-adaptation');
+            mergedDocument.setState(unit, translationState.needsWorkTranslation);
           }
         }
       }

--- a/src/features/tools/xlf/xlf-translationState.ts
+++ b/src/features/tools/xlf/xlf-translationState.ts
@@ -1,0 +1,5 @@
+export enum translationState {
+    missingTranslation = 0,
+    needsWorkTranslation = 1,
+    translated = 10
+}

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -456,7 +456,7 @@ function checkForNeedWorkTranslation(targetDocument: XlfDocument, unit: XmlNode,
         return true;
     }
 
-    if (targetDocument.getTargetAttribute(unit, 'state') === 'needs-adaptation') {
+    if (targetDocument.getState(unit) === translationState.needsWorkTranslation) {
         return true;
     }
 
@@ -464,7 +464,7 @@ function checkForNeedWorkTranslation(targetDocument: XlfDocument, unit: XmlNode,
 }
 
 function checkForResolvedProblem(targetDocument: XlfDocument, unit: XmlNode) : boolean {
-    return targetDocument.getTargetAttribute(unit, 'state') !== 'needs-adaptation' && targetDocument.tryDeleteXliffSyncNote(unit);
+    return targetDocument.getState(unit) !== translationState.needsWorkTranslation && targetDocument.tryDeleteXliffSyncNote(unit);
 }
 
 function checkForPlaceHolderMismatch(sourceText: string, translationText: string) {

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -39,6 +39,7 @@ import {
 } from 'vscode';
 import { XlfDocument } from './tools/xlf/xlf-document';
 import { FilesHelper, WorkspaceHelper, XmlNode } from './tools';
+import { translationState } from './tools/xlf/xlf-translationState';
 
 // Variables that should be accessible from events
 var currentEditor: TextEditor | undefined;
@@ -330,11 +331,11 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
 
             targetDocument.translationUnitNodes.forEach((unit) => {
                 if (shouldCheckForMissingTranslations && checkForMissingTranslation(targetDocument, unit, missingTranslationText)) {
-                    targetDocument.setTargetAttribute(unit, 'state', 'needs-translation');
+                    targetDocument.setState(unit, translationState.missingTranslation);
                     missingCount += 1;
                 }
                 if (shouldCheckForNeedWorkTranslations && checkForNeedWorkTranslation(targetDocument, unit, isRuleEnabledChecker, sourceEqualsTargetExpected)) {
-                    targetDocument.setTargetAttribute(unit, 'state', 'needs-adaptation');
+                    targetDocument.setState(unit, translationState.needsWorkTranslation);
                     needWorkCount += 1;
                 }
                 if (shouldCheckForNeedWorkTranslations && checkForResolvedProblem(targetDocument, unit)) {

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -254,11 +254,23 @@ export class XliffTranslationChecker {
     }
 
     private getNeedsWorkTranslationKeywords() : string {
+        const currentWorkspaceFolder: WorkspaceFolder | undefined = window.activeTextEditor ?
+            workspace.getWorkspaceFolder(window.activeTextEditor.document.uri) :
+            undefined;
+        let currentWorkspaceFolderUri: Uri | undefined = undefined;
+        if (currentWorkspaceFolder) {
+            currentWorkspaceFolderUri = currentWorkspaceFolder.uri;
+        }
+        let needsWorkTranslationSubstate = workspace.getConfiguration('xliffSync', currentWorkspaceFolderUri)[
+            'needsWorkTranslationSubstate'
+        ];
+
+        const segmentNeedsWorkRegExp: string = `(<segment.* subState="${needsWorkTranslationSubstate}".*>)`;
         if (decorationTargetTextOnly) {
-            return '(?<=<target state="needs-adaptation">).*(?=</target>)';
+            return `((?<=<target.* state="needs-adaptation".*>).*(?=</target>))|${segmentNeedsWorkRegExp}`;
         }
         else {
-            return '<target state="needs-adaptation">.*</target>|<target state="needs-adaptation"/>';
+            return `(<target.* state="needs-adaptation".*>.*</target>)|(<target.* state="needs-adaptation".*/>)|${segmentNeedsWorkRegExp}`;
         }
     }
 }


### PR DESCRIPTION
This PR makes various changes to better support XLIFF 2.0 files. Most notably, the states that are added to the nodes are now following the [XLIFF 2.0 specification](http://docs.oasis-open.org/xliff/xliff-core/v2.0/xliff-core-v2.0.html).
Please see the updated CHANGELOG for more information.

Resolves #50.