### PR TITLE
New setting to specify whether a needs-work translation note should be added

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,12 @@
                     "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.",
                     "scope": "resource"
                 },
+                "xliffSync.addNeedsWorkTranslationNote": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work.",
+                    "scope": "resource"
+                },
                 "xliffSync.missingTranslation": {
                     "type": "string",
                     "default": "%EMPTY%",

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -159,6 +159,7 @@ export class XlfDocument {
   private parseFromDeveloperNoteSeparator: string;
   private missingTranslation: string;
   private needsWorkTranslationSubstate: string;
+  private addNeedsWorkTranslationNote: boolean;
 
   private constructor(resourceUri: Uri | undefined) {
     const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', resourceUri);
@@ -173,6 +174,7 @@ export class XlfDocument {
       this.missingTranslation = '';
     }
     this.needsWorkTranslationSubstate = xliffWorkspaceConfiguration['needsWorkTranslationSubstate'];
+    this.addNeedsWorkTranslationNote = xliffWorkspaceConfiguration['addNeedsWorkTranslationNote'];
   }
 
   public static async load(source: string, resourceUri: Uri | undefined): Promise<XlfDocument> {
@@ -673,6 +675,10 @@ export class XlfDocument {
   }
 
   public setXliffSyncNote(unit: XmlNode, noteText: string) {
+    if (!this.addNeedsWorkTranslationNote) {
+      return;
+    }
+
     let noteAttributes: { [key: string]: string; } = {};
     const fromAttribute = 'XLIFF Sync';
     let notesParent: XmlNode | undefined = unit;


### PR DESCRIPTION
Adds a setting `xliffSync.addNeedsWorkTranslationNote` that can be used to change whether an "XLIFF Sync" note should be added to trans-units that are being marked as needs-work by the extension (which are added to explain what was detected).