### PR TITLE
New setting to automatically open files externally after certain events occur

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,27 @@
                     "description": "Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work.",
                     "scope": "resource"
                 },
+                "xliffSync.openExternallyAfterEvent": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "Check",
+                            "ProblemDetected",
+                            "Sync"
+                        ],
+                        "enumDescriptions": [
+                            "Open automatically after checking for missing translations or translation that needs work.",
+                            "Open automatically after a problem (missing translation or translation that needs work) was detected.",
+                            "Open automatically after syncing with the base translation file."
+                        ]
+                    },
+                    "default": [
+                    ],
+                    "uniqueItems": true,
+                    "description": "Specifies after which event translation files should be opened automatically with the default XLIFF editor",
+                    "scope": "resource"
+                },
                 "xliffSync.missingTranslation": {
                     "type": "string",
                     "default": "%EMPTY%",

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -201,7 +201,7 @@ export class FilesHelper {
     });
   }
 
-  public static async createNewTargetFile(targetUri: Uri | undefined, newFileContents: string, sourceUri?: Uri | undefined, targetLanguage?: string | undefined) {
+  public static async createNewTargetFile(targetUri: Uri | undefined, newFileContents: string, sourceUri?: Uri | undefined, targetLanguage?: string | undefined): Promise<Uri> {
     let document: TextDocument;
 
     if (targetUri) {
@@ -231,6 +231,8 @@ export class FilesHelper {
     });
 
     await document.save();
+
+    return targetUri;
   }
 
   public static getFileNameFromUri(fileUri: Uri): string {

--- a/src/features/trans-sync.ts
+++ b/src/features/trans-sync.ts
@@ -23,11 +23,13 @@
  */
 
 import {
+    env,
     ProgressLocation,
     QuickPickItem,
     Uri,
     window,
     workspace,
+    WorkspaceConfiguration,
     WorkspaceFolder
 } from 'vscode';
 
@@ -257,7 +259,12 @@ async function synchronizeTargetFile(sourceUri: Uri, targetUri: Uri | undefined,
             throw new Error('No ouput generated');
         }
     
-        await FilesHelper.createNewTargetFile(targetUri, newFileContents, sourceUri, targetLanguage);
+        targetUri = await FilesHelper.createNewTargetFile(targetUri, newFileContents, sourceUri, targetLanguage);
+        const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', workspaceFolder?.uri);
+        const openExternallyAfterEvent: string[] = xliffWorkspaceConfiguration['openExternallyAfterEvent'];
+        if (openExternallyAfterEvent.indexOf("Sync") > -1) {
+            env.openExternal(targetUri);
+        }
     });
 }
 


### PR DESCRIPTION
Adds a setting `xliffSync.openExternallyAfterEvent` that can be used to specify whether translation files should be opened automatically with the default XLIFF editor after an event takes place. By default, files will not be opened externally automatically.
You can set files to be opened externally automatically after:
* Checking translations
* Detecting problems
* Synchronizing translation files