### PR TITLE
New setting xliffSync.matchingOriginalOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.7.0] (Next Release)
 
 * Activate extension when any of the extension's commands are invoked.
+* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).
 
 ## [0.6.0] 26-11-2020
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,12 @@
                     "description": "Specifies whether the extension will sync from a base file to the translation files in all workspace folders.",
                     "scope": "window"
                 },
+                "xliffSync.matchingOriginalOnly": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether the extension will sync only to files where the original-attribute is matching.",
+                    "scope": "resource"
+                },
                 "xliffSync.findByXliffGeneratorNoteAndSource": {
                     "type": "boolean",
                     "default": true,

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -101,6 +101,16 @@ export class XlfDocument {
     }
   }
 
+  public get original(): string | undefined {
+    switch (this.version) {
+      case '1.2': case '2.0':
+        const fileNode = this.root && this.getNode('file', this.root);
+        return fileNode && fileNode.attributes && fileNode.attributes['original'];
+      default:
+        return undefined;
+    }
+  }
+
   public get translationUnitNodes(): XmlNode[] {
     if (!this.root) {
       return [];


### PR DESCRIPTION
New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).