### PR TITLE
New setting xliffSync.clearTranslationAfterSourceTextChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Activate extension when any of the extension's commands are invoked.
 * New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).
+* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`).
 
 ## [0.6.0] 26-11-2020
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.baseFile | `.g.xlf` | Specifies which XLIFF file to use as the base (e.g., the generated XLIFF). If the file does not exist, you will be prompted to specify the file to use as base-XLIFF file the first time you use the Synchronize command. |
 | xliffSync.fileType | `xlf` | The file type (`xlf` or `xlf2`). |
 | xliffSync.syncCrossWorkspaceFolders | `false` | Specifies whether the extension will sync from a base file to the translation files in all workspace folders. By default, the extension will always sync. per workspace folder. If you enable this setting, then you can have the base file in one workspace folder and target translation files in other workspace folders. |
+| xliffSync.matchingOriginalOnly | `true` | Specifies whether the extension will sync only to files where the original-attribute is matching. |
 | xliffSync.missingTranslation | `%EMPTY%` | The placeholder for missing translations for trans-units that were synced/merged into target XLIFF files. You can use `%EMPTY%` if you want to use an empty string for missing translations. |
 | xliffSync.needsWorkTranslationSubstate | `xliffSync:needsWork` | Specifies the substate to use for translations that need work in xlf2 files. **Tip**: If you use [Poedit](https://poedit.net/), then you could also set this to `poedit:fuzzy`. |
 | xliffSync.findByXliffGeneratorNoteAndSource | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and source. |
@@ -76,6 +77,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.copyFromSourceOverwrite | `false` | Specifies whether translations copied from the source text should overwrite existing translations. |
 | xliffSync.detectSourceTextChanges | `true` | Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed. |
 | xliffSync.ignoreLineEndingTypeChanges | `false` | Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit. |
+| xliffSync.clearTranslationAfterSourceTextChange | `false` | Specifies whether translations should be cleared when the source text of a trans-unit changed. |
 | xliffSync.addNeedsWorkTranslationNote | `true` | Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work. |
 | xliffSync.openExternallyAfterEvent | `[]` | Specifies after which event translation files should be opened automatically with the default XLIFF editor. Options: "Check", "ProblemDetected", "Sync" |
 | xliffSync.developerNoteDesignation | `Developer` | Specifies the name that is used to designate a developer note. |

--- a/package.json
+++ b/package.json
@@ -157,6 +157,12 @@
                     "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.",
                     "scope": "resource"
                 },
+                "xliffSync.clearTranslationAfterSourceTextChange": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether translations should be cleared when the source text of a trans-unit changed.",
+                    "scope": "resource"
+                },
                 "xliffSync.addNeedsWorkTranslationNote": {
                     "type": "boolean",
                     "default": true,

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -45,6 +45,7 @@ export class XlfTranslator {
     const parseFromDeveloperNote: boolean = xliffWorkspaceConfiguration['parseFromDeveloperNote'];
     const parseFromDeveloperNoteOverwrite: boolean = xliffWorkspaceConfiguration['parseFromDeveloperNoteOverwrite'];
     const detectSourceTextChanges: boolean = xliffWorkspaceConfiguration['detectSourceTextChanges'];
+    const clearTranslationAfterSourceTextChange: boolean = xliffWorkspaceConfiguration['clearTranslationAfterSourceTextChange'];
     const ignoreLineEndingTypeChanges: boolean = xliffWorkspaceConfiguration['ignoreLineEndingTypeChanges'];
     const missingTranslationKeyword: string = xliffWorkspaceConfiguration['missingTranslation'];
 
@@ -160,8 +161,14 @@ export class XlfTranslator {
           }
 
           if (mergedSourceText !== origSourceText) {
-            mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
-            mergedDocument.setState(unit, translationState.needsWorkTranslation);
+            if (clearTranslationAfterSourceTextChange) {
+              mergedDocument.clearUnitTranslation(unit);
+              mergedDocument.setState(unit, translationState.missingTranslation);
+            }
+            else {
+              mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
+              mergedDocument.setState(unit, translationState.needsWorkTranslation);
+            }
           }
         }
       }

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -648,6 +648,12 @@ export class XlfDocument {
     return this.getNode(stateNodeTag, unit);
   }
 
+  public clearUnitTranslation(unit: XmlNode) {
+    const targetNode = this.getNode('target', unit);
+    if (targetNode) {
+      targetNode.children = [];
+    }
+  }
 
   public setTargetAttribute(unit: XmlNode, attribute: string, attributeValue: string) {
     let targetNode: XmlNode | undefined = this.getNode('target', unit);


### PR DESCRIPTION
New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`).