### PR TITLE
Do not add state to target nodes for XLIFF 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [0.7.0] (Next Release)
+## [0.7.0] 04-02-2021
 
 * Activate extension when any of the extension's commands are invoked.
-* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).
-* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`).
+* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`). (GitHub issue [#51](https://github.com/rvanbekkum/vsc-xliff-sync/issues/51) + (GitHub issue [#66](https://github.com/rvanbekkum/vsc-xliff-sync/issues/66)))
+* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`). (GitHub issue [#64](https://github.com/rvanbekkum/vsc-xliff-sync/issues/64))
+* Fix: Do not add state to (new) target nodes in XLIFF 2.0 files. (GitHub issue [#57](https://github.com/rvanbekkum/vsc-xliff-sync/issues/57))
 
 ## [0.6.0] 26-11-2020
 

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -462,12 +462,14 @@ export class XlfDocument {
     const needsTranslation: boolean = this.getUnitNeedsTranslation(sourceUnit);
     if (needsTranslation && !targetNode) {
       let attributes: { [key: string]: string; } = {};
+      let newTranslationState: translationState = translationState.translated;
       if (!translation) {
         translation = this.missingTranslation;
-        this.updateStateAttributes(attributes, translationState.missingTranslation);
+        newTranslationState = translationState.missingTranslation;
       }
-      else {
-        this.updateStateAttributes(attributes, translationState.translated);
+
+      if (this.version == '1.2') {
+        this.updateStateAttributes(attributes, newTranslationState);
       }
 
       targetNode = this.createTargetNode(sourceUnit, attributes, translation);
@@ -482,7 +484,10 @@ export class XlfDocument {
         if (!targetNode.attributes) {
           targetNode.attributes = {};
         }
-        this.updateStateAttributes(targetNode.attributes, translationState.translated);
+
+        if (this.version == '1.2') {
+          this.updateStateAttributes(targetNode.attributes, translationState.translated);
+        }
       }
       this.appendTargetNode(sourceUnit, targetNode);
     }


### PR DESCRIPTION
Do not add state attribute to (new) target nodes for XLIFF 2.0 files.

Issue #57.