### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [0.7.0] (Next Release)
+## [0.7.0] 04-02-2021
 
 * Activate extension when any of the extension's commands are invoked.
-* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).
-* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`).
+* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`). (GitHub issue [#51](https://github.com/rvanbekkum/vsc-xliff-sync/issues/51) + (GitHub issue [#66](https://github.com/rvanbekkum/vsc-xliff-sync/issues/66)))
+* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`). (GitHub issue [#64](https://github.com/rvanbekkum/vsc-xliff-sync/issues/64))
+* Fix: Do not add state to (new) target nodes in XLIFF 2.0 files. (GitHub issue [#57](https://github.com/rvanbekkum/vsc-xliff-sync/issues/57))
 
 ## [0.6.0] 26-11-2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Activate extension when any of the extension's commands are invoked.
 * New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).
+* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`).
 
 ## [0.6.0] 26-11-2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 * New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`). (GitHub issue [#51](https://github.com/rvanbekkum/vsc-xliff-sync/issues/51) + (GitHub issue [#66](https://github.com/rvanbekkum/vsc-xliff-sync/issues/66)))
 * New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`). (GitHub issue [#64](https://github.com/rvanbekkum/vsc-xliff-sync/issues/64))
 * Fix: Do not add state to (new) target nodes in XLIFF 2.0 files. (GitHub issue [#57](https://github.com/rvanbekkum/vsc-xliff-sync/issues/57))
+* Added more details about files and workspace to error messages. (GitHub issue [#65](https://github.com/rvanbekkum/vsc-xliff-sync/issues/65))
+
+### Thank You
+
+* **[antpyykk](https://github.com/antpyykk)** for filing issue [#57](https://github.com/rvanbekkum/vsc-xliff-sync/issues/57).
+* **[catadumitru](https://github.com/catadumitru)** for filing issue [#64](https://github.com/rvanbekkum/vsc-xliff-sync/issues/64).
+* **[waldo1001](https://github.com/waldo1001)** for filing issues [#65](https://github.com/rvanbekkum/vsc-xliff-sync/issues/65) and [#66](https://github.com/rvanbekkum/vsc-xliff-sync/issues/66).
 
 ## [0.6.0] 26-11-2020
 
@@ -15,6 +22,11 @@ You can set files to be opened externally automatically after:
   * Checking translations
   * Detecting problems
   * Synchronizing translation files
+
+### Thank You
+
+* **[IceOnly](https://github.com/IceOnly)** for filing issue [#54](https://github.com/rvanbekkum/vsc-xliff-sync/issues/54).
+* **[htmnk](https://github.com/htmnk)** for filing issue [#56](https://github.com/rvanbekkum/vsc-xliff-sync/issues/56).
 
 ## [0.5.1] 03-09-2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.7.0] (Next Release)
+
+* Activate extension when any of the extension's commands are invoked.
+
 ## [0.6.0] 26-11-2020
 
 * New setting `xliffSync.addNeedsWorkTranslationNote` that can be used to change whether an "XLIFF Sync" note should be added to trans-units that are being marked as needs-work by the extension (which are added to explain what was detected) (**Default**: `true`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.7.0] (Next Release)
 
 * Activate extension when any of the extension's commands are invoked.
+* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`).
 
 ## [0.6.0] 26-11-2020
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.baseFile | `.g.xlf` | Specifies which XLIFF file to use as the base (e.g., the generated XLIFF). If the file does not exist, you will be prompted to specify the file to use as base-XLIFF file the first time you use the Synchronize command. |
 | xliffSync.fileType | `xlf` | The file type (`xlf` or `xlf2`). |
 | xliffSync.syncCrossWorkspaceFolders | `false` | Specifies whether the extension will sync from a base file to the translation files in all workspace folders. By default, the extension will always sync. per workspace folder. If you enable this setting, then you can have the base file in one workspace folder and target translation files in other workspace folders. |
+| xliffSync.matchingOriginalOnly | `true` | Specifies whether the extension will sync only to files where the original-attribute is matching. |
 | xliffSync.missingTranslation | `%EMPTY%` | The placeholder for missing translations for trans-units that were synced/merged into target XLIFF files. You can use `%EMPTY%` if you want to use an empty string for missing translations. |
 | xliffSync.needsWorkTranslationSubstate | `xliffSync:needsWork` | Specifies the substate to use for translations that need work in xlf2 files. **Tip**: If you use [Poedit](https://poedit.net/), then you could also set this to `poedit:fuzzy`. |
 | xliffSync.findByXliffGeneratorNoteAndSource | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and source. |
@@ -76,6 +77,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.copyFromSourceOverwrite | `false` | Specifies whether translations copied from the source text should overwrite existing translations. |
 | xliffSync.detectSourceTextChanges | `true` | Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed. |
 | xliffSync.ignoreLineEndingTypeChanges | `false` | Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit. |
+| xliffSync.clearTranslationAfterSourceTextChange | `false` | Specifies whether translations should be cleared when the source text of a trans-unit changed. |
 | xliffSync.addNeedsWorkTranslationNote | `true` | Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work. |
 | xliffSync.openExternallyAfterEvent | `[]` | Specifies after which event translation files should be opened automatically with the default XLIFF editor. Options: "Check", "ProblemDetected", "Sync" |
 | xliffSync.developerNoteDesignation | `Developer` | Specifies the name that is used to designate a developer note. |

--- a/package.json
+++ b/package.json
@@ -157,6 +157,12 @@
                     "description": "Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit.",
                     "scope": "resource"
                 },
+                "xliffSync.clearTranslationAfterSourceTextChange": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether translations should be cleared when the source text of a trans-unit changed.",
+                    "scope": "resource"
+                },
                 "xliffSync.addNeedsWorkTranslationNote": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -32,10 +32,16 @@
     ],
     "main": "./out/extension",
     "activationEvents": [
+        "onCommand:xliffSync.checkForMissingTranslations",
+        "onCommand:xliffSync.checkForNeedWorkTranslations",
+        "onCommand:xliffSync.createNewTargetFiles",
+        "onCommand:xliffSync.findNextMissingTarget",
+        "onCommand:xliffSync.findNextNeedsWorkTarget",
+        "onCommand:xliffSync.importTranslationsFromFiles",
         "onCommand:xliffSync.synchronizeFile",
+        "onCommand:xliffSync.synchronizeSources",
         "workspaceContains:**/*.xlf",
-        "workspaceContains:**/*.xlf2",
-        "onCommand:xliffSync.findNextMissingTarget"
+        "workspaceContains:**/*.xlf2"
     ],
     "contributes": {
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,12 @@
                     "description": "Specifies whether the extension will sync from a base file to the translation files in all workspace folders.",
                     "scope": "window"
                 },
+                "xliffSync.matchingOriginalOnly": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether the extension will sync only to files where the original-attribute is matching.",
+                    "scope": "resource"
+                },
                 "xliffSync.findByXliffGeneratorNoteAndSource": {
                     "type": "boolean",
                     "default": true,

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -68,7 +68,7 @@ export class FilesHelper {
     }
 
     if (!uris.length) {
-        throw new Error('No translation file found');
+        throw new Error(`No translation file found (Workspace: "${workspaceFolder?.name}").`);
     }
 
     return uris;

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -45,6 +45,7 @@ export class XlfTranslator {
     const parseFromDeveloperNote: boolean = xliffWorkspaceConfiguration['parseFromDeveloperNote'];
     const parseFromDeveloperNoteOverwrite: boolean = xliffWorkspaceConfiguration['parseFromDeveloperNoteOverwrite'];
     const detectSourceTextChanges: boolean = xliffWorkspaceConfiguration['detectSourceTextChanges'];
+    const clearTranslationAfterSourceTextChange: boolean = xliffWorkspaceConfiguration['clearTranslationAfterSourceTextChange'];
     const ignoreLineEndingTypeChanges: boolean = xliffWorkspaceConfiguration['ignoreLineEndingTypeChanges'];
     const missingTranslationKeyword: string = xliffWorkspaceConfiguration['missingTranslation'];
 
@@ -160,8 +161,14 @@ export class XlfTranslator {
           }
 
           if (mergedSourceText !== origSourceText) {
-            mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
-            mergedDocument.setState(unit, translationState.needsWorkTranslation);
+            if (clearTranslationAfterSourceTextChange) {
+              mergedDocument.clearUnitTranslation(unit);
+              mergedDocument.setState(unit, translationState.missingTranslation);
+            }
+            else {
+              mergedDocument.setXliffSyncNote(unit, 'Source text has changed. Please review the translation.');
+              mergedDocument.setState(unit, translationState.needsWorkTranslation);
+            }
           }
         }
       }

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -648,6 +648,12 @@ export class XlfDocument {
     return this.getNode(stateNodeTag, unit);
   }
 
+  public clearUnitTranslation(unit: XmlNode) {
+    const targetNode = this.getNode('target', unit);
+    if (targetNode) {
+      targetNode.children = [];
+    }
+  }
 
   public setTargetAttribute(unit: XmlNode, attribute: string, attributeValue: string) {
     let targetNode: XmlNode | undefined = this.getNode('target', unit);

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -462,12 +462,14 @@ export class XlfDocument {
     const needsTranslation: boolean = this.getUnitNeedsTranslation(sourceUnit);
     if (needsTranslation && !targetNode) {
       let attributes: { [key: string]: string; } = {};
+      let newTranslationState: translationState = translationState.translated;
       if (!translation) {
         translation = this.missingTranslation;
-        this.updateStateAttributes(attributes, translationState.missingTranslation);
+        newTranslationState = translationState.missingTranslation;
       }
-      else {
-        this.updateStateAttributes(attributes, translationState.translated);
+
+      if (this.version == '1.2') {
+        this.updateStateAttributes(attributes, newTranslationState);
       }
 
       targetNode = this.createTargetNode(sourceUnit, attributes, translation);
@@ -482,7 +484,10 @@ export class XlfDocument {
         if (!targetNode.attributes) {
           targetNode.attributes = {};
         }
-        this.updateStateAttributes(targetNode.attributes, translationState.translated);
+
+        if (this.version == '1.2') {
+          this.updateStateAttributes(targetNode.attributes, translationState.translated);
+        }
       }
       this.appendTargetNode(sourceUnit, targetNode);
     }

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -187,10 +187,25 @@ export class XlfDocument {
     this.addNeedsWorkTranslationNote = xliffWorkspaceConfiguration['addNeedsWorkTranslationNote'];
   }
 
+  public static async loadFromUri(sourceUri: Uri, resourceUri: Uri | undefined): Promise<XlfDocument> {
+    try {
+    const source: string = (await workspace.openTextDocument(sourceUri)).getText();
+    return await this.load(source, resourceUri);
+    }
+    catch (ex) {
+      throw new Error(`${ex.message}; File: ${sourceUri}`);
+    }
+  }
+
   public static async load(source: string, resourceUri: Uri | undefined): Promise<XlfDocument> {
-    const doc = new XlfDocument(resourceUri);
-    doc.root = await new XmlParser().parseDocument(source);
-    return doc;
+    try {
+      const doc = new XlfDocument(resourceUri);
+      doc.root = await new XmlParser().parseDocument(source);
+      return doc;
+    }
+    catch (ex) {
+      throw new Error(`Failed to load XLIFF document, error: ${ex.message}`);
+    }
   }
 
   public static create(version: '1.2' | '2.0', language: string, resourceUri: Uri | undefined): XlfDocument {

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -101,6 +101,16 @@ export class XlfDocument {
     }
   }
 
+  public get original(): string | undefined {
+    switch (this.version) {
+      case '1.2': case '2.0':
+        const fileNode = this.root && this.getNode('file', this.root);
+        return fileNode && fileNode.attributes && fileNode.attributes['original'];
+      default:
+        return undefined;
+    }
+  }
+
   public get translationUnitNodes(): XmlNode[] {
     if (!this.root) {
       return [];

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -321,17 +321,11 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
             if (!targetUri) {
                 continue;
             }
-            const target = targetUri
-                ? (await workspace.openTextDocument(targetUri)).getText()
-                : undefined;
-            if (!target) {
-                continue;
-            }
 
             let missingCount: number = 0;
             let needWorkCount: number = 0;
             let problemResolvedInFile: boolean = false;
-            const targetDocument = await XlfDocument.load(target, checkWorkspaceFolder?.uri);
+            const targetDocument = await XlfDocument.loadFromUri(targetUri, checkWorkspaceFolder?.uri);
             sourceEqualsTargetExpected = targetDocument.sourceLanguage === targetDocument.targetLanguage;
             if (targetDocument.targetLanguage) {
                 sourceEqualsTargetExpected = sourceEqualsTargetExpected || (copyFromSourceForLanguages.indexOf(targetDocument.targetLanguage) >= 0);
@@ -383,7 +377,7 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
                 const newFileContents = targetDocument.extract();
 
                 if (!newFileContents) {
-                    throw new Error('No ouput generated');
+                    throw new Error(`No ouput generated. File ${targetUri}`);
                 }
     
                 await FilesHelper.createNewTargetFile(targetUri, newFileContents);

--- a/src/features/trans-import.ts
+++ b/src/features/trans-import.ts
@@ -90,8 +90,7 @@ async function importTranslationsFromFile(workspaceFolder: WorkspaceFolder, file
     }
     const replaceTranslationsDuringImport: boolean = workspace.getConfiguration('xliffSync', workspaceFolder.uri)['replaceTranslationsDuringImport'];
 
-    const selFileContents = (await workspace.openTextDocument(fileUri)).getText();
-    const selFileDocument = await XlfDocument.load(selFileContents, workspaceFolder.uri);
+    const selFileDocument = await XlfDocument.loadFromUri(fileUri, workspaceFolder.uri);
     let sourceDevNoteTranslations: { [key: string]: string | undefined; } = {};
     selFileDocument.translationUnitNodes.forEach((unit) => {
         const sourceDevNoteText = getSourceDevNoteText(selFileDocument, unit);
@@ -108,14 +107,8 @@ async function importTranslationsFromFile(workspaceFolder: WorkspaceFolder, file
         if (!targetUri) {
             continue;
         }
-        const target = targetUri
-            ? (await workspace.openTextDocument(targetUri)).getText()
-            : undefined;
-        if (!target) {
-            continue;
-        }
 
-        const targetDocument = await XlfDocument.load(target, workspaceFolder.uri);
+        const targetDocument = await XlfDocument.loadFromUri(targetUri, workspaceFolder.uri);
         if (targetDocument.targetLanguage !== selFileDocument.targetLanguage) {
             continue;
         }
@@ -155,7 +148,7 @@ async function importTranslationsFromFile(workspaceFolder: WorkspaceFolder, file
             const newFileContents = targetDocument.extract();
 
             if (!newFileContents) {
-                throw new Error('No ouput generated');
+                throw new Error(`No ouput generated. File: ${targetUri}`);
             }
 
             await FilesHelper.createNewTargetFile(targetUri, newFileContents);


### PR DESCRIPTION
* Activate extension when any of the extension's commands are invoked.
* New setting `xliffSync.matchingOriginalOnly` that can be used to specify whether to sync. only to files where the `original` attribute of the `file`-node of an XLIFF file matches that of the base file (**Default**: `true`). (GitHub issue [#51](https://github.com/rvanbekkum/vsc-xliff-sync/issues/51) + (GitHub issue [#66](https://github.com/rvanbekkum/vsc-xliff-sync/issues/66)))
* New setting `xliffSync.clearTranslationAfterSourceTextChange` that can be used to specify whether the translation for trans-units should be cleared during syncing if a change in the source text is detected (instead of marking it as needs-work) (**Default**: `false`). (GitHub issue [#64](https://github.com/rvanbekkum/vsc-xliff-sync/issues/64))
* Fix: Do not add state to (new) target nodes in XLIFF 2.0 files. (GitHub issue [#57](https://github.com/rvanbekkum/vsc-xliff-sync/issues/57))
* Added more details about files and workspace to error messages. (GitHub issue [#65](https://github.com/rvanbekkum/vsc-xliff-sync/issues/65))