### PR TITLE
Handling Large Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Next Release
+
+* Optimized syncing through a preprocessing step that builds up unit maps. The existing implementation approaches O(n^2) while this optimization implemented brings it down to O(n) (with n being the number of translation units). This optimization was already applied earlier in the PowerShell version (see [ps-xliff-sync](https://github.com/rvanbekkum/ps-xliff-sync)). The new setting `xliffSync.unitMaps` can be used to change whether and to which extent these maps should be used (**Default**: `"All"`).
+
+### Thank You
+
+* **[fvet](https://github.com/fvet)** for requesting support for handling large files. (GitHub issue [#31](https://github.com/rvanbekkum/vsc-xliff-sync/issues/31))
+
 ## [0.7.0] 04-02-2021
 
 * Activate extension when any of the extension's commands are invoked.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.fileType | `xlf` | The file type (`xlf` or `xlf2`). |
 | xliffSync.syncCrossWorkspaceFolders | `false` | Specifies whether the extension will sync from a base file to the translation files in all workspace folders. By default, the extension will always sync. per workspace folder. If you enable this setting, then you can have the base file in one workspace folder and target translation files in other workspace folders. |
 | xliffSync.matchingOriginalOnly | `true` | Specifies whether the extension will sync only to files where the original-attribute is matching. |
+| xliffSync.unitMaps | `All` | Specifies for which search purposes this command should create in-memory maps in preparation of syncing. |
 | xliffSync.missingTranslation | `%EMPTY%` | The placeholder for missing translations for trans-units that were synced/merged into target XLIFF files. You can use `%EMPTY%` if you want to use an empty string for missing translations. |
 | xliffSync.needsWorkTranslationSubstate | `xliffSync:needsWork` | Specifies the substate to use for translations that need work in xlf2 files. **Tip**: If you use [Poedit](https://poedit.net/), then you could also set this to `poedit:fuzzy`. |
 | xliffSync.findByXliffGeneratorNoteAndSource | `true` | Specifies whether or not the extension will try to find trans-units by XLIFF generator note and source. |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -73,6 +73,22 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Specifies whether the extension will sync only to files where the original-attribute is matching.",
+                    "scope": "resource"
+                },
+                "xliffSync.unitMaps": {
+                    "type": "string",
+                    "default": "All",
+                    "description": "Specifies for which search purposes this command should create in-memory maps in preparation of syncing.",
+                    "enum": [
+                        "None",
+                        "Id",
+                        "All"
+                    ],
+                    "enumDescriptions": [
+                        "Do not use in-memory maps.",
+                        "Only use an in-memory map for finding units by ID.",
+                        "Use in-memory maps for all search purposes."
+                    ],
                     "scope": "resource"
                 },
                 "xliffSync.findByXliffGeneratorNoteAndSource": {

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -272,11 +272,25 @@ export class XlfDocument {
     const findByIsEnabled: boolean = findByXliffGenNotesIsEnabled || findBySourceAndDeveloperNote || findBySource;
 
     this.idUnitMap = {}
-    this.xliffGeneratorNoteSourceUnitMap = {};
-    this.xliffGeneratorNoteDeveloperNoteUnitMap = {};
-    this.xliffGeneratorNoteUnitMap = {};
-    this.sourceDeveloperNoteUnitMap = {};
-    this.sourceUnitMap = {};
+    if (findByIsEnabled) {
+      if (findByXliffGenNotesIsEnabled) {
+        if (findByXliffGeneratorNoteAndSource) {
+          this.xliffGeneratorNoteSourceUnitMap = {};
+        }
+        if (findByXliffGeneratorAndDeveloperNote) {
+          this.xliffGeneratorNoteDeveloperNoteUnitMap = {};
+        }
+        if (findByXliffGeneratorNote) {
+          this.xliffGeneratorNoteUnitMap = {};
+        }
+      }
+      if (findBySourceAndDeveloperNote) {
+        this.sourceDeveloperNoteUnitMap = {};
+      }
+      if (findBySource) {
+        this.sourceUnitMap = {};
+      }
+    }
 
     this.translationUnitNodes.forEach((unit) => {
         if (!(unit.attributes.id in this.idUnitMap!)) {

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -171,6 +171,13 @@ export class XlfDocument {
   private needsWorkTranslationSubstate: string;
   private addNeedsWorkTranslationNote: boolean;
 
+  private idUnitMap: { [id: string]: XmlNode } | undefined;
+  private xliffGeneratorNoteSourceUnitMap: { [key: string]: XmlNode } | undefined;
+  private xliffGeneratorNoteDeveloperNoteUnitMap: { [key: string]: XmlNode } | undefined;
+  private xliffGeneratorNoteUnitMap: { [key: string]: XmlNode } | undefined;
+  private sourceDeveloperNoteUnitMap: { [key: string]: XmlNode } | undefined;
+  private sourceUnitMap: { [key: string]: XmlNode } | undefined;
+
   private constructor(resourceUri: Uri | undefined) {
     const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', resourceUri);
     this.developerNoteDesignation = xliffWorkspaceConfiguration['developerNoteDesignation'];
@@ -260,7 +267,77 @@ export class XlfDocument {
     return retVal;
   }
 
+  public CreateUnitMaps(findByXliffGeneratorNoteAndSource: boolean, findByXliffGeneratorAndDeveloperNote: boolean, findByXliffGeneratorNote: boolean, findBySourceAndDeveloperNote: boolean, findBySource: boolean): void {
+    const findByXliffGenNotesIsEnabled: boolean = findByXliffGeneratorNoteAndSource || findByXliffGeneratorAndDeveloperNote || findByXliffGeneratorNote;
+    const findByIsEnabled: boolean = findByXliffGenNotesIsEnabled || findBySourceAndDeveloperNote || findBySource;
+
+    this.idUnitMap = {}
+    this.xliffGeneratorNoteSourceUnitMap = {};
+    this.xliffGeneratorNoteDeveloperNoteUnitMap = {};
+    this.xliffGeneratorNoteUnitMap = {};
+    this.sourceDeveloperNoteUnitMap = {};
+    this.sourceUnitMap = {};
+
+    this.translationUnitNodes.forEach((unit) => {
+        if (!(unit.attributes.id in this.idUnitMap!)) {
+            this.idUnitMap![unit.attributes.id] = unit;
+        }
+
+        if (findByIsEnabled) {
+            const developerNote: string | undefined = this.getUnitDeveloperNote(unit);
+            const sourceText: string | undefined = this.getUnitSource(unit);
+
+            if (findByXliffGenNotesIsEnabled) {
+                const xliffGeneratorNote: string | undefined = this.getUnitXliffGeneratorNote(unit);
+
+                if (findByXliffGeneratorNoteAndSource && (xliffGeneratorNote || sourceText)) {
+                    const key: string | undefined = [xliffGeneratorNote, sourceText].toString();
+                    if (key && !(key in this.xliffGeneratorNoteSourceUnitMap!)) {
+                      this.xliffGeneratorNoteSourceUnitMap![key] = unit;
+                    }
+                }
+                if (findByXliffGeneratorAndDeveloperNote && (xliffGeneratorNote || developerNote)) {
+                    const key: string | undefined = [xliffGeneratorNote, developerNote].toString();
+                    if (key && !(key in this.xliffGeneratorNoteDeveloperNoteUnitMap!)) {
+                        this.xliffGeneratorNoteDeveloperNoteUnitMap![key] = unit;
+                    }
+                }
+                if (findByXliffGeneratorNote) {
+                    const key: string | undefined = xliffGeneratorNote;
+                    if (key && !(key in this.xliffGeneratorNoteUnitMap!)) {
+                        this.xliffGeneratorNoteUnitMap![key] = unit;
+                    }
+                }
+            }
+
+            if (findBySourceAndDeveloperNote && (sourceText || developerNote)) {
+                const key: string | undefined = [sourceText, developerNote].toString();
+                if (key && !(key in this.sourceDeveloperNoteUnitMap!)) {
+                    const translationText: string | undefined = this.getUnitTranslation(unit);
+                    if (translationText) {
+                      this.sourceDeveloperNoteUnitMap![key] = unit;
+                    }
+                }
+            }
+
+            if (findBySource && (sourceText && !(sourceText in this.sourceUnitMap!))) {
+              const translationText: string | undefined = this.getUnitTranslation(unit);
+              if (translationText) {
+                this.sourceUnitMap![sourceText] = unit;
+              }
+            }
+        }
+    });
+  }
+
   public findTranslationUnit(id: string): XmlNode | undefined {
+    if (this.idUnitMap) {
+      if (id in this.idUnitMap) {
+        return this.idUnitMap[id];
+      }
+      return undefined;
+    }
+
     return this.translationUnitNodes.find((node) => node.attributes.id === id);
   }
 
@@ -268,12 +345,27 @@ export class XlfDocument {
     xliffGenNote: string,
     source: string,
   ): XmlNode | undefined {
+    if (this.xliffGeneratorNoteSourceUnitMap) {
+      const key: string | undefined = [xliffGenNote, source].toString();
+      if (key in this.xliffGeneratorNoteSourceUnitMap) {
+        return this.xliffGeneratorNoteSourceUnitMap[key];
+      }
+      return undefined;
+    }
+
     return this.translationUnitNodes.find(
       (node) => this.getUnitXliffGeneratorNote(node) === xliffGenNote && this.getUnitSource(node) === source,
     );
   }
 
   public findTranslationUnitByXliffGeneratorNote(xliffGenNote: string): XmlNode | undefined {
+    if (this.xliffGeneratorNoteUnitMap) {
+      if (xliffGenNote in this.xliffGeneratorNoteUnitMap) {
+        return this.xliffGeneratorNoteUnitMap[xliffGenNote];
+      }
+      return undefined;
+    }
+
     return this.translationUnitNodes.find((node) => this.getUnitXliffGeneratorNote(node) === xliffGenNote);
   }
 
@@ -281,6 +373,14 @@ export class XlfDocument {
     xliffGenNote: string,
     devNote: string,
   ): XmlNode | undefined {
+    if (this.xliffGeneratorNoteDeveloperNoteUnitMap) {
+      const key: string | undefined = [xliffGenNote, devNote].toString();
+      if (key in this.xliffGeneratorNoteDeveloperNoteUnitMap) {
+        return this.xliffGeneratorNoteDeveloperNoteUnitMap[key];
+      }
+      return undefined;
+    }
+
     return this.translationUnitNodes.find(
       (node) =>
         this.getUnitXliffGeneratorNote(node) === xliffGenNote && this.getUnitDeveloperNote(node) === devNote,
@@ -291,12 +391,27 @@ export class XlfDocument {
     source: string,
     devNote: string | undefined,
   ): XmlNode | undefined {
+    if (this.sourceDeveloperNoteUnitMap) {
+      const key: string | undefined = [source, devNote].toString();
+      if (key in this.sourceDeveloperNoteUnitMap) {
+        return this.sourceDeveloperNoteUnitMap[key];
+      }
+      return undefined;
+    }
+
     return this.translationUnitNodes.find(
       (node) => 
         (this.getUnitSource(node) === source) && (this.getUnitDeveloperNote(node) === devNote) && this.getUnitTranslation(node) !== undefined);
   }
 
   public findFirstTranslationUnitBySource(source: string): XmlNode | undefined {
+    if (this.sourceUnitMap) {
+      if (source in this.sourceUnitMap) {
+        return this.sourceUnitMap[source];
+      }
+      return undefined;
+    }
+
     return this.translationUnitNodes.find((node) => this.getUnitSource(node) === source && this.getUnitTranslation(node) !== undefined);
   }
 


### PR DESCRIPTION
Optimized syncing through a preprocessing step that builds up unit maps. The existing implementation approaches O(n^2) while this optimization implemented brings it down to O(n) (with n being the number of translation units). This optimization was already applied earlier in the PowerShell version (see [ps-xliff-sync](https://github.com/rvanbekkum/ps-xliff-sync)). The new setting `xliffSync.unitMaps` can be used to change whether and to which extent these maps should be used (**Default**: `"All"`).