### PR TITLE
Preserve Target Child Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Next Release
 
-* Optimized syncing through a preprocessing step that builds up unit maps. The existing implementation approaches O(n^2) while this optimization implemented brings it down to O(n) (with n being the number of translation units). This optimization was already applied earlier in the PowerShell version (see [ps-xliff-sync](https://github.com/rvanbekkum/ps-xliff-sync)). The new setting `xliffSync.unitMaps` can be used to change whether and to which extent these maps should be used (**Default**: `"All"`).
+* Optimized syncing through a preprocessing step that builds up unit maps. The existing implementation approaches O(n^2) while this optimization implemented brings it down to O(n) (with n being the number of translation units). This optimization was already applied earlier in the PowerShell version (see [ps-xliff-sync](https://github.com/rvanbekkum/ps-xliff-sync)). The new setting `xliffSync.unitMaps` can be used to change whether and to which extent these maps should be used (**Default**: `"All"`). (GitHub issue [#31](https://github.com/rvanbekkum/vsc-xliff-sync/issues/31))
+* New setting `xliffSync.preserveTargetChildNodes` that can be used to specify whether child nodes specific to the translation target file should be preserved while syncing. Currently this setting will preserve `alt-trans` nodes and custom nodes for XLIFF 1.2 files. (**Default**: `false`) (GitHub issue [#60](https://github.com/rvanbekkum/vsc-xliff-sync/issues/60))
 
 ### Thank You
 
 * **[fvet](https://github.com/fvet)** for requesting support for handling large files. (GitHub issue [#31](https://github.com/rvanbekkum/vsc-xliff-sync/issues/31))
+* **[markusguenther](https://github.com/markusguenther)** for requesting support for preserving `alt-trans` child nodes in target files. (GitHub issue [#60](https://github.com/rvanbekkum/vsc-xliff-sync/issues/60))
 
 ## [0.7.0] 04-02-2021
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.needWorkTranslationRulesEnableAll | `false` | Specifies whether or not all available technical validation rules should be used. Enabling this setting makes `xliffSync.needWorkTranslationRules` redundant. |
 | xliffSync.preserveTargetAttributes | `false` | Specifies whether or not syncing should use the attributes from the target files for the trans-unit nodes while syncing. |
 | xliffSync.preserveTargetAttributesOrder | `false` | Specifies whether the attributes of trans-unit nodes should use the order found in the target files while syncing. |
+| xliffSync.preserveTargetChildNodes | `false` | Specifies whether child nodes of trans-unit nodes specific to the target files should be preserved. This will preserve `alt-trans` nodes and custom nodes in XLIFF 1.2 target files. |
 | xliffSync.replaceTranslationsDuringImport | `false` | Specifies whether existing translations will be replaced when the XLIFF: Import Translations from File(s) command is run. |
 | xliffSync.decoration | `{"backgroundColor": "rgba(240, 210, 105, 0.35)", "overviewRulerColor": "rgba(240, 210, 105, 0.35)", "border": "1px solid white", "borderRadius": "4px"}` | Specifies how to highlight missing translations or translations that need work in an XLIFF file opened in the editor. |
 | xliffSync.decorationEnabled | `true` | Specifies whether decorations for missing translations and translations that need work should be applied. |

--- a/package.json
+++ b/package.json
@@ -292,6 +292,12 @@
                     "description": "Specifies whether the attributes of trans-unit nodes should use the order found in the target files while syncing.",
                     "scope": "resource"
                 },
+                "xliffSync.preserveTargetChildNodes": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether translation-specific child nodes of trans-units in the target files should be preserved.",
+                    "scope": "resource"
+                },
                 "xliffSync.replaceTranslationsDuringImport": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
New setting `xliffSync.preserveTargetChildNodes` that can be used to specify whether child nodes specific to the translation target file should be preserved while syncing. Currently this setting will preserve `alt-trans` nodes and custom nodes for XLIFF 1.2 files. (**Default**: `false`) (GitHub issue [#60](https://github.com/rvanbekkum/vsc-xliff-sync/issues/60))