### PR TITLE
Support translations with child-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 * Optimized syncing through a preprocessing step that builds up unit maps. The existing implementation approaches O(n^2) while this optimization implemented brings it down to O(n) (with n being the number of translation units). This optimization was already applied earlier in the PowerShell version (see [ps-xliff-sync](https://github.com/rvanbekkum/ps-xliff-sync)). The new setting `xliffSync.unitMaps` can be used to change whether and to which extent these maps should be used (**Default**: `"All"`). (GitHub issue [#31](https://github.com/rvanbekkum/vsc-xliff-sync/issues/31))
 * New setting `xliffSync.preserveTargetChildNodes` that can be used to specify whether child nodes specific to the translation target file should be preserved while syncing. Currently this setting will preserve `alt-trans` nodes and custom nodes for XLIFF 1.2 files. (**Default**: `false`) (GitHub issue [#60](https://github.com/rvanbekkum/vsc-xliff-sync/issues/60))
+* The extension can now handle units with child nodes (e.g., placeholder tags like `<x/>`) in the target node. (GitHub issue [#67](https://github.com/rvanbekkum/vsc-xliff-sync/issues/67))
 
 ### Thank You
 
 * **[fvet](https://github.com/fvet)** for requesting support for handling large files. (GitHub issue [#31](https://github.com/rvanbekkum/vsc-xliff-sync/issues/31))
 * **[markusguenther](https://github.com/markusguenther)** for requesting support for preserving `alt-trans` child nodes in target files. (GitHub issue [#60](https://github.com/rvanbekkum/vsc-xliff-sync/issues/60))
+* **[olalinv](https://github.com/olalinv)** for request support for child nodes in target nodes. (GitHub issue [#67](https://github.com/rvanbekkum/vsc-xliff-sync/issues/67))
 
 ## [0.7.0] 04-02-2021
 

--- a/src/features/tools/xml-builder.ts
+++ b/src/features/tools/xml-builder.ts
@@ -26,7 +26,7 @@ import { create, XMLElementOrXMLNode } from 'xmlbuilder';
 import { XmlNode } from './xml-node';
 
 export class XmlBuilder {
-  public static create(root: XmlNode | undefined): string | undefined {
+  public static create(root: XmlNode | undefined, headless: boolean = false): string | undefined {
     if (!root) {
       return undefined;
     }
@@ -34,6 +34,7 @@ export class XmlBuilder {
     const outputNode: XMLElementOrXMLNode = create(root.name, {
       version: '1.0',
       encoding: 'UTF-8',
+      headless: headless,
       stringify: {
         attValue: (str: string) =>
           str

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -243,7 +243,7 @@ export class XliffTranslationChecker {
             'missingTranslation'
         ];
         if (missingTranslationKeyword === '%EMPTY%') {
-            missingTranslationKeyword = '<target.*( state="needs-translation")?.*/>|<target.*( state="needs-translation")?.*></target>';
+            missingTranslationKeyword = '<target[^>]*( state="needs-translation")?[^>]*/>|<target.*( state="needs-translation")?.*></target>';
         }
         else if (decorationTargetTextOnly) {
             missingTranslationKeyword = `(?<=<target.*( state="needs-translation")?.*>)${missingTranslationKeyword}(?=</target>)`;
@@ -271,7 +271,7 @@ export class XliffTranslationChecker {
             return `((?<=<target.* state="needs-adaptation".*>).*(?=</target>))|${segmentNeedsWorkRegExp}`;
         }
         else {
-            return `(<target.* state="needs-adaptation".*>.*</target>)|(<target.* state="needs-adaptation".*/>)|${segmentNeedsWorkRegExp}`;
+            return `(<target.* state="needs-adaptation".*>.*</target>)|(<target[^>]* state="needs-adaptation"[^>]*/>)|${segmentNeedsWorkRegExp}`;
         }
     }
 }
@@ -404,7 +404,7 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
 function checkForMissingTranslation(targetDocument: XlfDocument, unit: XmlNode, missingTranslationText: string) : boolean {
     const needsTranslation: boolean = targetDocument.getUnitNeedsTranslation(unit);
     if (needsTranslation) {
-        const translation = targetDocument.getUnitTranslation(unit);
+        const translation = targetDocument.getUnitTranslationText(unit);
         if (!translation || translation === missingTranslationText) {
             return true;
         }
@@ -414,7 +414,7 @@ function checkForMissingTranslation(targetDocument: XlfDocument, unit: XmlNode, 
 
 function checkForNeedWorkTranslation(targetDocument: XlfDocument, unit: XmlNode, isRuleEnabled: (ruleName: string) => boolean, sourceEqualsTargetExpected: boolean) : boolean {
     const sourceText = targetDocument.getUnitSourceText(unit);
-    const translText = targetDocument.getUnitTranslation(unit);
+    const translText = targetDocument.getUnitTranslationText(unit);
     const devNoteText = targetDocument.getUnitDeveloperNote(unit) || '';
     if (!sourceText || !translText) {
         return false;

--- a/src/features/trans-import.ts
+++ b/src/features/trans-import.ts
@@ -91,13 +91,13 @@ async function importTranslationsFromFile(workspaceFolder: WorkspaceFolder, file
     const replaceTranslationsDuringImport: boolean = workspace.getConfiguration('xliffSync', workspaceFolder.uri)['replaceTranslationsDuringImport'];
 
     const selFileDocument = await XlfDocument.loadFromUri(fileUri, workspaceFolder.uri);
-    let sourceDevNoteTranslations: { [key: string]: string | undefined; } = {};
+    let sourceDevNoteTranslations: { [key: string]: (XmlNode | string)[]; } = {};
     selFileDocument.translationUnitNodes.forEach((unit) => {
         const sourceDevNoteText = getSourceDevNoteText(selFileDocument, unit);
         if (sourceDevNoteText && !(sourceDevNoteText in sourceDevNoteTranslations)) {
-            const translText = selFileDocument.getUnitTranslation(unit);
-            if (translText) {
-                sourceDevNoteTranslations[sourceDevNoteText] = translText;
+            const translChildNodes = selFileDocument.getUnitTranslationChildren(unit);
+            if (translChildNodes) {
+                sourceDevNoteTranslations[sourceDevNoteText] = translChildNodes;
             }
         }
     });
@@ -115,7 +115,7 @@ async function importTranslationsFromFile(workspaceFolder: WorkspaceFolder, file
 
         let translationsImported: number = 0;
         targetDocument.translationUnitNodes.forEach((unit) => {
-            if (!replaceTranslationsDuringImport && targetDocument.getUnitTranslation(unit)) {
+            if (!replaceTranslationsDuringImport && targetDocument.getUnitTranslationText(unit)) {
                 return;
             }
 


### PR DESCRIPTION
Properly handle units with child nodes (e.g., placeholder tags like `<x/>`) in the target node. The extension used to only expect strings as child node for `target` nodes.

Resolves #67.