### PR TITLE
New feature: Define equivalent languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@
 * Optimized syncing through a preprocessing step that builds up unit maps. The existing implementation approaches O(n^2) while this optimization implemented brings it down to O(n) (with n being the number of translation units). This optimization was already applied earlier in the PowerShell version (see [ps-xliff-sync](https://github.com/rvanbekkum/ps-xliff-sync)). The new setting `xliffSync.unitMaps` can be used to change whether and to which extent these maps should be used (**Default**: `"All"`). (GitHub issue [#31](https://github.com/rvanbekkum/vsc-xliff-sync/issues/31))
 * New setting `xliffSync.preserveTargetChildNodes` that can be used to specify whether child nodes specific to the translation target file should be preserved while syncing. Currently this setting will preserve `alt-trans` nodes and custom nodes for XLIFF 1.2 files. (**Default**: `false`) (GitHub issue [#60](https://github.com/rvanbekkum/vsc-xliff-sync/issues/60))
 * The extension can now handle units with child nodes (e.g., placeholder tags like `<x/>`) in the target node. (GitHub issue [#67](https://github.com/rvanbekkum/vsc-xliff-sync/issues/67))
+* New settings `xliffSync.equivalentLanguages` and `xliffSync.equivalentLanguagesEnabled` that can be used to specify equivalent languages. You can specify pairs of master language and slave language-pattern (RegEx) in the `xliffSync.equivalentLanguages` setting to have the extension copy to contents of the master language's translation file to the translation files of its slave languages. This way you only need to enter the translations for the master language, so that after you sync. again the slave languages will get the same translations, and you don't need to go through all languages files that would get the same translations. For example, _often_ `nl-NL` and `nl-BE` would simply get the same translations, so this way you could specify that `nl-BE` should take over all the translations of `nl-NL`.
+  * The default value for `xliffSync.equivalentLanguagesEnabled` is `false`.
+  * The default value for `xliffSync.equivalentLanguages` is
+
+    ```json
+    {
+      "de-DE": "de-.*",
+      "en-US": "en-.*",
+      "es-ES": "es-.*",
+      "fr-FR": "fr-.*",
+      "nl-NL": "nl-.*"
+    }
+    ```
+
+    You can freely customize this, e.g., adding `"en-GB"` as a master language for `"(en-AU)|(en-NZ)"` and changing `"en-US"` to be a master language for `"en-CA"` if you do have differences between `en-US` and `en-GB` in your translations:
+
+    ```json
+    {
+      "de-DE": "de-.*",
+      "en-GB": "(en-AU)|(en-NZ)",
+      "en-US": "en-CA",
+      "es-ES": "es-.*",
+      "fr-FR": "fr-.*",
+      "nl-NL": "nl-.*"
+    }
+    ```
+
+* New setting `xliffSync.keepEditorOpenAfterSync` that can be used to specify whether XLIFF files should be open in the editor after syncing.
 
 ### Thank You
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.parseFromDeveloperNote | `false` | Specifies whether translations should be parsed from the developer note. Translations can be retrieved from a Developer note in the following format: <code>en-US=My translation&#124;nl-NL=Mijn vertaling</code>. |
 | xliffSync.parseFromDeveloperNoteOverwrite | `false` | Specifies whether translations parsed from the developer note should always overwrite existing translations. |
 | xliffSync.parseFromDeveloperNoteSeparator | <code>&#124;</code> | Specifies the separator that is used when translations are parsed from the developer note. |
-| xliffSync.equivalentLanguages | `{ "de-DE": "de-.*", "en-US": "en-.*", "es-ES": "es-.*", "fr-FR": "fr-.*", "nl-NL": "nl-.*" }` | Specifies a master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language. |
+| xliffSync.equivalentLanguages | `{ "de-DE": "de-.*", "en-US": "en-.*", "es-ES": "es-.*", "fr-FR": "fr-.*", "nl-NL": "nl-.*" }` | Specifies master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language. |
 | xliffSync.equivalentLanguagesEnabled | `false` | Specifies whether languages should be treated as equivalent as specified in the xliffSync.equivalentLanguages setting. |
 | xliffSync.copyFromSourceForLanguages | `[]` | Specifies the languages for which translations should be copied from the source text of trans-units. |
 | xliffSync.copyFromSourceForSameLanguage | `false` | Specifies whether translations should be copied from the source text if source-language = target-language. This will **not** overwrite existing translations of trans-units in target files. |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.parseFromDeveloperNote | `false` | Specifies whether translations should be parsed from the developer note. Translations can be retrieved from a Developer note in the following format: <code>en-US=My translation&#124;nl-NL=Mijn vertaling</code>. |
 | xliffSync.parseFromDeveloperNoteOverwrite | `false` | Specifies whether translations parsed from the developer note should always overwrite existing translations. |
 | xliffSync.parseFromDeveloperNoteSeparator | <code>&#124;</code> | Specifies the separator that is used when translations are parsed from the developer note. |
+| xliffSync.equivalentLanguages | `{ "de-DE": "de-.*", "en-US": "en-.*", "es-ES": "es-.*", "fr-FR": "fr-.*", "nl-NL": "nl-.*" }` | Specifies a master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language. |
+| xliffSync.equivalentLanguagesEnabled | `false` | Specifies whether languages should be treated as equivalent as specified in the xliffSync.equivalentLanguages setting. |
 | xliffSync.copyFromSourceForLanguages | `[]` | Specifies the languages for which translations should be copied from the source text of trans-units. |
 | xliffSync.copyFromSourceForSameLanguage | `false` | Specifies whether translations should be copied from the source text if source-language = target-language. This will **not** overwrite existing translations of trans-units in target files. |
 | xliffSync.copyFromSourceOverwrite | `false` | Specifies whether translations copied from the source text should overwrite existing translations. |
@@ -80,6 +82,7 @@ Apart from synchronizing trans-units from a base-XLIFF file, this extension cont
 | xliffSync.ignoreLineEndingTypeChanges | `false` | Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit. |
 | xliffSync.clearTranslationAfterSourceTextChange | `false` | Specifies whether translations should be cleared when the source text of a trans-unit changed. |
 | xliffSync.addNeedsWorkTranslationNote | `true` | Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work. |
+| xliffSync.keepEditorOpenAfterSync | `false` | Specifies whether XLIFF files should be opened in the editor after syncing. |
 | xliffSync.openExternallyAfterEvent | `[]` | Specifies after which event translation files should be opened automatically with the default XLIFF editor. Options: "Check", "ProblemDetected", "Sync" |
 | xliffSync.developerNoteDesignation | `Developer` | Specifies the name that is used to designate a developer note. |
 | xliffSync.xliffGeneratorNoteDesignation | `Xliff Generator` | Specifies the name that is used to designate a XLIFF generator note. |

--- a/package.json
+++ b/package.json
@@ -139,6 +139,27 @@
                     "description": "Specifies the separator that is used when translations are parsed from the developer note.",
                     "scope": "resource"
                 },
+                "xliffSync.equivalentLanguages": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {
+                        "de-DE": "de-.*",
+                        "en-US": "en-.*",
+                        "es-ES": "es-.*",
+                        "fr-FR": "fr-.*",
+                        "nl-NL": "nl-.*"
+                    },
+                    "description": "Specifies a master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language.",
+                    "scope": "resource"
+                },
+                "xliffSync.equivalentLanguagesEnabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether languages should be treated as equivalent as specified in the xliffSync.equivalentLanguages setting.",
+                    "scope": "resource"
+                },
                 "xliffSync.copyFromSourceForLanguages": {
                     "type": "array",
                     "items": {
@@ -183,6 +204,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work.",
+                    "scope": "resource"
+                },
+                "xliffSync.keepEditorOpenAfterSync": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether XLIFF files should be opened in the editor after syncing.",
                     "scope": "resource"
                 },
                 "xliffSync.openExternallyAfterEvent": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
                         "fr-FR": "fr-.*",
                         "nl-NL": "nl-.*"
                     },
-                    "description": "Specifies a master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language.",
+                    "description": "Specifies master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language.",
                     "scope": "resource"
                 },
                 "xliffSync.equivalentLanguagesEnabled": {

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -30,7 +30,8 @@ import {
   window,
   workspace,
   WorkspaceFolder,
-  RelativePattern
+  RelativePattern,
+  commands
 } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -231,6 +232,11 @@ export class FilesHelper {
     });
 
     await document.save();
+
+    let keepEditorOpenAfterSync: boolean = workspace.getConfiguration('xliffSync', targetUri)['keepEditorOpenAfterSync'];
+    if (!keepEditorOpenAfterSync) {
+      await commands.executeCommand('workbench.action.closeActiveEditor');
+    }
 
     return targetUri;
   }


### PR DESCRIPTION
* New settings `xliffSync.equivalentLanguages` and `xliffSync.equivalentLanguagesEnabled` that can be used to specify equivalent languages. You can specify pairs of master language and slave language-pattern (RegEx) in the `xliffSync.equivalentLanguages` setting to have the extension copy to contents of the master language's translation file to the translation files of its slave languages. This way you only need to enter the translations for the master language, so that after you sync. again the slave languages will get the same translations, and you don't need to go through all languages files that would get the same translations. For example, _often_ `nl-NL` and `nl-BE` would simply get the same translations, so this way you could specify that `nl-BE` should take over all the translations of `nl-NL`.
  * The default value for `xliffSync.equivalentLanguagesEnabled` is `false`.
  * The default value for `xliffSync.equivalentLanguages` is

    ```json
    {
      "de-DE": "de-.*",
      "en-US": "en-.*",
      "es-ES": "es-.*",
      "fr-FR": "fr-.*",
      "nl-NL": "nl-.*"
    }
    ```

    You can freely customize this, e.g., adding `"en-GB"` as a master language for `"(en-AU)|(en-NZ)"` and changing `"en-US"` to be a master language for `"en-CA"` if you do have differences between `en-US` and `en-GB` in your translations:

    ```json
    {
      "de-DE": "de-.*",
      "en-GB": "(en-AU)|(en-NZ)",
      "en-US": "en-CA",
      "es-ES": "es-.*",
      "fr-FR": "fr-.*",
      "nl-NL": "nl-.*"
    }
    ```

* New setting `xliffSync.keepEditorOpenAfterSync` that can be used to specify whether XLIFF files should be open in the editor after syncing.

Issue: #74 