### PR TITLE
Fix for new units getting state "translated" with empty content

### DIFF
--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -687,7 +687,7 @@ export class XlfDocument {
     }
 
     if (needsTranslation && targetNode) {
-      if (translChildNodes) {
+      if (translChildNodes && !(translChildNodes.length === 1 && translChildNodes[0] === this.missingTranslation)) {
         targetNode.children = translChildNodes;
         if (!targetNode.attributes) {
           targetNode.attributes = {};


### PR DESCRIPTION
Fix for issue #81, introduced in the latest release.