### PR TITLE
Patch equivalentLanguages (use workspaceFolder)

### DIFF
--- a/src/features/trans-sync.ts
+++ b/src/features/trans-sync.ts
@@ -278,7 +278,10 @@ async function synchronizeAllFiles(sourceUri: Uri, targetUris: Uri[], workspaceF
     const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', workspaceFolder?.uri);
     const matchingOriginalOnly: string[] = xliffWorkspaceConfiguration['matchingOriginalOnly'];
 
-    const equivalentLanguages = xliffWorkspaceConfiguration['equivalentLanguages'];
+    let equivalentLanguages: any = xliffWorkspaceConfiguration.inspect('equivalentLanguages')?.workspaceFolderValue;
+    if (!equivalentLanguages) {
+        equivalentLanguages = xliffWorkspaceConfiguration['equivalentLanguages'];
+    }
     const equivalentLanguagesEnabled: boolean = xliffWorkspaceConfiguration['equivalentLanguagesEnabled'];
     let slavesToMaster: {[id: string]: string} = {};
     if (equivalentLanguagesEnabled) {


### PR DESCRIPTION
Use workspaceFolder value for `xliffSync.equivalentLanguages` setting.

Addresses problem reported in issue #87.