### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.2.0] 21-06-2021
+
+* Fixed "Open Externally" no longer working after Visual Studio Code update 1.57.0. This may be a work-around that will be reverted later on. (GitHub issue [#89](https://github.com/rvanbekkum/vsc-xliff-sync/issues/89))
+* Patch "equivalent languages" feature not allowing to override default value but instead merging the setting values (this was not intended). (GitHub issue [#87](https://github.com/rvanbekkum/vsc-xliff-sync/issues/87))
+
+### Thank You
+
+* **[fvet](https://github.com/fvet)** for reporting the issue with the "equivalent languages" feature (GitHub issue [#87](https://github.com/rvanbekkum/vsc-xliff-sync/issues/87))
+* **[dannoe](https://github.com/dannoe)** for reporting "Open Externally" no longer working after Visual Studio Code update 1.57.0 (GitHub issue [#89](https://github.com/rvanbekkum/vsc-xliff-sync/issues/89)) and for your pull request (Pull Request [#90](https://github.com/rvanbekkum/vsc-xliff-sync/pull/90)).
+
 ## [1.1.0] 26-02-2021
 
 * Fixed new unit nodes getting `state="translated"` with no translation. Bug due to changes for GitHub issue [#67](https://github.com/rvanbekkum/vsc-xliff-sync/issues/67). (GitHub issue [#81](https://github.com/rvanbekkum/vsc-xliff-sync/issues/81))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xliff-sync",
-  "version": "0.4.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -179,6 +179,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -254,6 +259,19 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -286,6 +304,16 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "open": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
+      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -498,6 +498,7 @@
         "arrowParens": "always"
     },
     "dependencies": {
+        "open": "^8.2.0",
         "sax": "^1.2.4",
         "xml2js": "^0.4.19",
         "xmlbuilder": "^9.0.7"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -25,7 +25,6 @@
 import {
     commands,
     DecorationRenderOptions,
-    env,
     ExtensionContext,
     Range,
     Selection,
@@ -41,6 +40,7 @@ import {
 import { XlfDocument } from './tools/xlf/xlf-document';
 import { FilesHelper, WorkspaceHelper, XmlNode } from './tools';
 import { translationState } from './tools/xlf/xlf-translationState';
+import open = require('open');
 
 // Variables that should be accessible from events
 var currentEditor: TextEditor | undefined;
@@ -367,7 +367,7 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
                 const fileName = FilesHelper.getFileNameFromUri(targetUri);
                 window.showInformationMessage(`"${fileName}":${messagesText}`, 'Open Externally').then(selection => {
                     if (selection === 'Open Externally') {
-                        env.openExternal(targetUri);
+                        open(decodeURIComponent(targetUri.toString()));
                     }
                 });
             }
@@ -383,7 +383,7 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
                 await FilesHelper.createNewTargetFile(targetUri, newFileContents);
             }
             if (openExternallyAutomatically) {
-                env.openExternal(targetUri);
+                open(decodeURIComponent(targetUri.toString()));
             }
         }
 

--- a/src/features/trans-import.ts
+++ b/src/features/trans-import.ts
@@ -21,9 +21,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { ExtensionContext, window, commands, OpenDialogOptions, Uri, workspace, env, WorkspaceFolder, WorkspaceConfiguration } from "vscode";
+import { ExtensionContext, window, commands, OpenDialogOptions, Uri, workspace, WorkspaceFolder, WorkspaceConfiguration } from "vscode";
 import { XlfDocument } from './tools/xlf/xlf-document';
 import { FilesHelper, WorkspaceHelper, XmlNode } from './tools';
+import open = require("open");
 
 export class XliffTranslationImport {
     constructor(context: ExtensionContext) {
@@ -142,7 +143,7 @@ async function importTranslationsFromFile(workspaceFolder: WorkspaceFolder, file
             const messagesText = ` ${translationsImported} translation(s) imported.`;
             window.showInformationMessage(`"${fileName}":${messagesText}`, 'Open Externally').then(selection => {
                 if (selection === 'Open Externally') {
-                    env.openExternal(targetUri);
+                    open(decodeURIComponent(targetUri.toString()));
                 }
             });
 

--- a/src/features/trans-sync.ts
+++ b/src/features/trans-sync.ts
@@ -278,7 +278,10 @@ async function synchronizeAllFiles(sourceUri: Uri, targetUris: Uri[], workspaceF
     const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', workspaceFolder?.uri);
     const matchingOriginalOnly: string[] = xliffWorkspaceConfiguration['matchingOriginalOnly'];
 
-    const equivalentLanguages = xliffWorkspaceConfiguration['equivalentLanguages'];
+    let equivalentLanguages: any = xliffWorkspaceConfiguration.inspect('equivalentLanguages')?.workspaceFolderValue;
+    if (!equivalentLanguages) {
+        equivalentLanguages = xliffWorkspaceConfiguration['equivalentLanguages'];
+    }
     const equivalentLanguagesEnabled: boolean = xliffWorkspaceConfiguration['equivalentLanguagesEnabled'];
     let slavesToMaster: {[id: string]: string} = {};
     if (equivalentLanguagesEnabled) {

--- a/src/features/trans-sync.ts
+++ b/src/features/trans-sync.ts
@@ -22,8 +22,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import open = require('open');
 import {
-    env,
     ProgressLocation,
     QuickPickItem,
     Uri,
@@ -265,7 +265,7 @@ async function synchronizeTargetFile(sourceUri: Uri, targetUri: Uri | undefined,
             const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', workspaceFolder?.uri);
             const openExternallyAfterEvent: string[] = xliffWorkspaceConfiguration['openExternallyAfterEvent'];
             if (openExternallyAfterEvent.indexOf("Sync") > -1) {
-                env.openExternal(targetUri);
+                open(decodeURIComponent(targetUri.toString()));
             }
         }
         catch (ex) {


### PR DESCRIPTION
* Fixed "Open Externally" no longer working after Visual Studio Code update 1.57.0. This may be a work-around that will be reverted later on. (GitHub issue [#89](https://github.com/rvanbekkum/vsc-xliff-sync/issues/89))
* Patch "equivalent languages" feature not allowing to override default value but instead merging the setting values (this was not intended). (GitHub issue [#87](https://github.com/rvanbekkum/vsc-xliff-sync/issues/87))

Updated CHANGELOG accordingly.