### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.3.0]
+## [1.3.0] 19-05-2022
 
 * New setting `xliffSync.parseFromDeveloperNoteTrimCharacters` that can be used to specify the characters to trim from the translations parsed from the developer notes. (GitHub issue [#100](https://github.com/rvanbekkum/vsc-xliff-sync/issues/100))
 * Included `needs-l10n` to be considered as a needs-work state. (GitHub issue [#102](https://github.com/rvanbekkum/vsc-xliff-sync/issues/102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.3.0]
+
+* New setting `xliffSync.parseFromDeveloperNoteTrimCharacters` that can be used to specify the characters to trim from the translations parsed from the developer notes. (GitHub issue [#100](https://github.com/rvanbekkum/vsc-xliff-sync/issues/100))
+* Included `needs-l10n` to be considered as a needs-work state. (GitHub issue [#102](https://github.com/rvanbekkum/vsc-xliff-sync/issues/102))
+
+### Thank You
+
+* **[fvet](https://github.com/fvet)** for your feature request for setting `xliffSync.parseFromDeveloperNoteTrimCharacters` (GitHub issue [#100](https://github.com/rvanbekkum/vsc-xliff-sync/issues/100))
+
 ## [1.2.0] 21-06-2021
 
 * Fixed "Open Externally" no longer working after Visual Studio Code update 1.57.0. This may be a work-around that will be reverted later on. (GitHub issue [#89](https://github.com/rvanbekkum/vsc-xliff-sync/issues/89))

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ More information: [XLIFF Sync: Time for a complete overview](https://robvanbekku
 | xliffSync.parseFromDeveloperNote | `false` | Specifies whether translations should be parsed from the developer note. Translations can be retrieved from a Developer note in the following format: <code>en-US=My translation&#124;nl-NL=Mijn vertaling</code>. |
 | xliffSync.parseFromDeveloperNoteOverwrite | `false` | Specifies whether translations parsed from the developer note should always overwrite existing translations. |
 | xliffSync.parseFromDeveloperNoteSeparator | <code>&#124;</code> | Specifies the separator that is used when translations are parsed from the developer note. |
+| xliffSync.parseFromDeveloperNoteTrimCharacters | `` | Specifies the characters that will be trimmed from the translation. |
 | xliffSync.equivalentLanguages | `{ "de-DE": "de-.*", "en-US": "en-.*", "es-ES": "es-.*", "fr-FR": "fr-.*", "nl-NL": "nl-.*" }` | Specifies master and slave languages that should be treated as equivalent, i.e., translations are copied from the master language. |
 | xliffSync.equivalentLanguagesEnabled | `false` | Specifies whether languages should be treated as equivalent as specified in the xliffSync.equivalentLanguages setting. |
 | xliffSync.copyFromSourceForLanguages | `[]` | Specifies the languages for which translations should be copied from the source text of trans-units. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,434 +1,978 @@
 {
-  "name": "xliff-sync",
-  "version": "1.1.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "13.13.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-      "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
-      "dev": true
-    },
-    "@types/sax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.0.0.tgz",
-      "integrity": "sha1-MNXmvb8Sba9uQSxjklHdl0vUfNw=",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/vscode": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-      "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
-      "dev": true
-    },
-    "@types/xml2js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
-      "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/xml2json": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@types/xml2json/-/xml2json-0.10.0.tgz",
-      "integrity": "sha1-6Wfh7WLOemcmbXOdeEhsxX4SVpc=",
-      "dev": true
-    },
-    "@types/xmlbuilder": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.32.tgz",
-      "integrity": "sha512-pYpeUBPFwOga4mkz9kpfua5dUBNUjPGiasg+O1HFYJpJy/NqQhnhm95NFMD9U1825AIrEVyWx0kvAKsV3+CZAA==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
+    "name": "xliff-sync",
+    "version": "1.3.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "xliff-sync",
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "open": "^8.2.0",
+                "sax": "^1.2.4",
+                "xml2js": "^0.4.19",
+                "xmlbuilder": "^9.0.7"
+            },
+            "devDependencies": {
+                "@types/mocha": "^7.0.2",
+                "@types/node": "^13.11.0",
+                "@types/sax": "^1.0.0",
+                "@types/vscode": "^1.47.0",
+                "@types/xml2js": "^0.4.2",
+                "@types/xml2json": "^0.10.0",
+                "@types/xmlbuilder": "0.0.32",
+                "tslint": "^5.8.0",
+                "typescript": "^4.0.0"
+            },
+            "engines": {
+                "vscode": "^1.47.0"
+            }
+        },
+        "node_modules/@types/mocha": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+            "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+            "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "13.13.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
+            "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+            "dev": true
+        },
+        "node_modules/@types/sax": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.0.0.tgz",
+            "integrity": "sha1-MNXmvb8Sba9uQSxjklHdl0vUfNw=",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
+            "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+            "dev": true
+        },
+        "node_modules/@types/xml2js": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
+            "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/xml2json": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@types/xml2json/-/xml2json-0.10.0.tgz",
+            "integrity": "sha1-6Wfh7WLOemcmbXOdeEhsxX4SVpc=",
+            "dev": true
+        },
+        "node_modules/@types/xmlbuilder": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.32.tgz",
+            "integrity": "sha512-pYpeUBPFwOga4mkz9kpfua5dUBNUjPGiasg+O1HFYJpJy/NqQhnhm95NFMD9U1825AIrEVyWx0kvAKsV3+CZAA==",
+            "dev": true
+        },
+        "node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            }
+        },
+        "node_modules/babel-code-frame/node_modules/chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+            "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/chalk/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+            "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "^1.1.1"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "node_modules/commander": {
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "dev": true,
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "node_modules/glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "node_modules/js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/open": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
+            "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "node_modules/resolve": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+            "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+            "dev": true,
+            "dependencies": {
+                "path-parse": "^1.0.5"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "node_modules/semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+            "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+            "dev": true
+        },
+        "node_modules/tslint": {
+            "version": "5.9.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+            "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+            "dev": true,
+            "dependencies": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.12.1"
+            },
+            "bin": {
+                "tslint": "bin/tslint"
+            },
+            "engines": {
+                "node": ">=4.8.0"
+            }
+        },
+        "node_modules/tsutils": {
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.25.0.tgz",
+            "integrity": "sha512-SPgUlOAUAe6fCyPi0QR4U0jRuDsHHKvzIR6/hHd0YR0bb8MzeLJgCagkPSmZeJjWImnpJ0xq6XHa9goTvMBBCQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "engines": {
+                "node": ">=4.0"
+            }
         }
-      }
     },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
-    "chalk": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "dependencies": {
+    "dependencies": {
+        "@types/mocha": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+            "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "13.13.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
+            "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+            "dev": true
+        },
+        "@types/sax": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.0.0.tgz",
+            "integrity": "sha1-MNXmvb8Sba9uQSxjklHdl0vUfNw=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/vscode": {
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
+            "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+            "dev": true
+        },
+        "@types/xml2js": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
+            "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/xml2json": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@types/xml2json/-/xml2json-0.10.0.tgz",
+            "integrity": "sha1-6Wfh7WLOemcmbXOdeEhsxX4SVpc=",
+            "dev": true
+        },
+        "@types/xmlbuilder": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.32.tgz",
+            "integrity": "sha512-pYpeUBPFwOga4mkz9kpfua5dUBNUjPGiasg+O1HFYJpJy/NqQhnhm95NFMD9U1825AIrEVyWx0kvAKsV3+CZAA==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+            "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "^1.1.1"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+        },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "open": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
+            "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
+            "requires": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+            "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.5"
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "tslib": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+            "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+            "dev": true
+        },
+        "tslint": {
+            "version": "5.9.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+            "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.12.1"
+            }
+        },
+        "tsutils": {
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.25.0.tgz",
+            "integrity": "sha512-SPgUlOAUAe6fCyPi0QR4U0jRuDsHHKvzIR6/hHd0YR0bb8MzeLJgCagkPSmZeJjWImnpJ0xq6XHa9goTvMBBCQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "typescript": {
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
-      }
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.1.1"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
-    },
-    "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "requires": {
-        "is-docker": "^2.0.0"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "open": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
-      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
-    },
-    "resolve": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
-      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.5"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
-    },
-    "tslint": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
-      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
-      }
-    },
-    "tsutils": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.25.0.tgz",
-      "integrity": "sha512-SPgUlOAUAe6fCyPi0QR4U0jRuDsHHKvzIR6/hHd0YR0bb8MzeLJgCagkPSmZeJjWImnpJ0xq6XHa9goTvMBBCQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
-    },
-    "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-      "dev": true
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -495,7 +495,7 @@
         "@types/xml2json": "^0.10.0",
         "@types/xmlbuilder": "0.0.32",
         "tslint": "^5.8.0",
-        "typescript": "^3.8.3"
+        "typescript": "^4.0.0"
     },
     "prettier": {
         "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xliff-sync",
     "displayName": "XLIFF Sync",
     "description": "A tool to keep XLIFF translation files in sync.",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "publisher": "rvanbekkum",
     "repository": {
         "type": "git",
@@ -137,6 +137,12 @@
                     "type": "string",
                     "default": "|",
                     "description": "Specifies the separator that is used when translations are parsed from the developer note.",
+                    "scope": "resource"
+                },
+                "xliffSync.parseFromDeveloperNoteTrimCharacters": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Specifies the characters that will be trimmed from the translation.",
                     "scope": "resource"
                 },
                 "xliffSync.equivalentLanguages": {

--- a/src/features/tools/files-helper.ts
+++ b/src/features/tools/files-helper.ts
@@ -41,7 +41,7 @@ export class FilesHelper {
 
   /**
   * Get the list of XLIFF files in the opened workspace
-  * 
+  *
   * @param {WorkspaceFolder} workspaceFolder The folder to restrict the search to.
   *
   * @returns An array of all file URIs to the XLIFF files in the current workspace.
@@ -78,7 +78,7 @@ export class FilesHelper {
   /**
    * Retrieves the base/source/generated XLIFF file from a collection of XLIFF file URIs.
    * Also prompts the user to specify a base file, if this wasn't done already.
-   * 
+   *
    * @param {Uri[]} xliffUris Array of XLIFF file URIs.
    * @param {WorkspaceFolder} workspaceFolder The workspace folder to restrict the search to.
    * @returns The Uri of the base/source XLIFF file.
@@ -116,7 +116,7 @@ export class FilesHelper {
       const sourcePath = await window.showQuickPick(fsPaths, {
           placeHolder: 'Select the base XLIFF file',
       });
-  
+
       if (!sourcePath) {
           return undefined;
       }
@@ -207,7 +207,7 @@ export class FilesHelper {
 
     if (targetUri) {
       document = await workspace.openTextDocument(targetUri);
-    } 
+    }
     else if (sourceUri) {
       targetUri = await FilesHelper.createTranslationFile(targetLanguage!, sourceUri, newFileContents);
       document = await workspace.openTextDocument(targetUri);

--- a/src/features/tools/workspace-helper.ts
+++ b/src/features/tools/workspace-helper.ts
@@ -26,7 +26,7 @@ import { workspace, WorkspaceFolder, window } from "vscode";
 export class WorkspaceHelper {
     public static async getWorkspaceFolders(allFiles: boolean): Promise<WorkspaceFolder[] | undefined> {
         let syncWorkspaceFolders: WorkspaceFolder[] | undefined = workspace.workspaceFolders?.concat([]);
-        
+
         const syncCrossWorkspaceFolders: boolean = workspace.getConfiguration('xliffSync')['syncCrossWorkspaceFolders'];
         if (syncCrossWorkspaceFolders) {
             return syncWorkspaceFolders;
@@ -38,17 +38,17 @@ export class WorkspaceHelper {
         if (currentWorkspaceFolder) {
             return [currentWorkspaceFolder];
         }
-        
+
         if (!allFiles && syncWorkspaceFolders && syncWorkspaceFolders.length > 1) {
             currentWorkspaceFolder = await window.showWorkspaceFolderPick({
-              placeHolder: 'Select a workspace folder' 
+              placeHolder: 'Select a workspace folder'
             });
             syncWorkspaceFolders = undefined;
             if (currentWorkspaceFolder) {
                 syncWorkspaceFolders = [currentWorkspaceFolder];
             }
         }
-    
+
         return syncWorkspaceFolders;
       }
 }

--- a/src/features/tools/xlf-translator.ts
+++ b/src/features/tools/xlf-translator.ts
@@ -96,19 +96,19 @@ export class XlfTranslator {
 
         if (findByXliffGenNotesIsEnabled) {
           const xliffGeneratorNote = mergedDocument.getUnitXliffGeneratorNote(unit);
-          
+
           if (xliffGeneratorNote) {
             if (findByXliffGeneratorNoteAndSource && xliffGeneratorNote && source) {
               targetUnit = targetDocument.findTranslationUnitByXliffGeneratorNoteAndSource(xliffGeneratorNote, source);
             }
-    
+
             if (!targetUnit && findByXliffGeneratorAndDeveloperNote && xliffGeneratorNote && developerNote) {
               targetUnit = targetDocument.findTranslationUnitByXliffGeneratorAndDeveloperNote(
                 xliffGeneratorNote,
                 developerNote,
               );
             }
-    
+
             if (!targetUnit && findByXliffGeneratorNote && xliffGeneratorNote) {
               targetUnit = targetDocument.findTranslationUnitByXliffGeneratorNote(xliffGeneratorNote);
             }

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -821,6 +821,7 @@ export class XlfDocument {
               case 'needs-translation':
                 return translationState.missingTranslation;
               case 'needs-adaptation':
+              case 'needs-l10n':
                 return translationState.needsWorkTranslation;
               case 'translated':
                 return translationState.translated;

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -168,6 +168,7 @@ export class XlfDocument {
   private preserveTargetOrder: boolean;
   private preserveTargetChildNodes: boolean;
   private parseFromDeveloperNoteSeparator: string;
+  private parseFromDeveloperNoteTrimCharacters: string;
   private missingTranslation: string;
   private needsWorkTranslationSubstate: string;
   private addNeedsWorkTranslationNote: boolean;
@@ -187,6 +188,7 @@ export class XlfDocument {
     this.preserveTargetOrder = xliffWorkspaceConfiguration['preserveTargetAttributesOrder'];
     this.preserveTargetChildNodes = xliffWorkspaceConfiguration['preserveTargetChildNodes'];
     this.parseFromDeveloperNoteSeparator = xliffWorkspaceConfiguration['parseFromDeveloperNoteSeparator'];
+    this.parseFromDeveloperNoteTrimCharacters = xliffWorkspaceConfiguration['parseFromDeveloperNoteTrimCharacters'];
 
     this.missingTranslation = xliffWorkspaceConfiguration['missingTranslation'];
     if (this.missingTranslation === '%EMPTY%') {
@@ -597,7 +599,28 @@ export class XlfDocument {
       }
     }
 
+    if (this.parseFromDeveloperNoteTrimCharacters != "") {
+      translation = this.trimAny(translation, this.parseFromDeveloperNoteTrimCharacters)
+    }
+
     return translation;
+  }
+
+  private trimAny(str: string | undefined, chars: string): string | undefined {
+    if (!str) {
+      return str;
+    }
+
+    var start = 0;
+    var end = str.length;
+
+    while(start < end && chars.indexOf(str[start]) >= 0)
+        ++start;
+
+    while(end > start && chars.indexOf(str[end - 1]) >= 0)
+        --end;
+
+    return (start > 0 || end < str.length) ? str.substring(start, end) : str;
   }
 
   public mergeUnit(sourceUnit: XmlNode, targetUnit: XmlNode | undefined, translChildNodes: (XmlNode | string)[] | undefined): void {

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -416,7 +416,7 @@ export class XlfDocument {
     }
 
     return this.translationUnitNodes.find(
-      (node) => 
+      (node) =>
         (this.getUnitSource(node) === source) && (this.getUnitDeveloperNote(node) === devNote) && this.getUnitTranslationText(node) !== undefined);
   }
 

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -71,19 +71,19 @@ export class XliffTranslationChecker {
         );
 
         const checkForMissingTranslationsDisposable = commands.registerCommand(
-            'xliffSync.checkForMissingTranslations', 
+            'xliffSync.checkForMissingTranslations',
             async() => {
                 this.checkForMissingTranslations();
             }
         );
 
         const checkForNeedWorkTranslationsDisposable = commands.registerCommand(
-            'xliffSync.checkForNeedWorkTranslations', 
+            'xliffSync.checkForNeedWorkTranslations',
             async() => {
                 this.checkForNeedWorkTranslations();
             }
         );
-        
+
         context.subscriptions.push(findNextMissingDisposable);
         context.subscriptions.push(findNextNeedsWorkDisposable);
         context.subscriptions.push(checkForMissingTranslationsDisposable);
@@ -281,7 +281,7 @@ export async function runTranslationChecks(shouldCheckForMissingTranslations: bo
     if (!checkWorkspaceFolders) {
         throw new Error(`No workspace folder found to use`);
     }
-    
+
     for (let checkWorkspaceFolder of checkWorkspaceFolders) {
         await runTranslationChecksForWorkspaceFolder(shouldCheckForMissingTranslations, shouldCheckForNeedWorkTranslations, undefined, checkWorkspaceFolder);
     }
@@ -379,7 +379,7 @@ export async function runTranslationChecksForWorkspaceFolder(shouldCheckForMissi
                 if (!newFileContents) {
                     throw new Error(`No ouput generated. File ${targetUri}`);
                 }
-    
+
                 await FilesHelper.createNewTargetFile(targetUri, newFileContents);
             }
             if (openExternallyAutomatically) {
@@ -428,7 +428,7 @@ function checkForNeedWorkTranslation(targetDocument: XlfDocument, unit: XmlNode,
             }
         }
     }
-    
+
     if (isRuleEnabled('Placeholders') && checkForPlaceHolderMismatch(sourceText, translText)) {
         targetDocument.setXliffSyncNote(unit, 'Problem detected: The number of placeholders in the source and translation text do not match.');
         return true;

--- a/src/features/trans-import.ts
+++ b/src/features/trans-import.ts
@@ -34,7 +34,7 @@ export class XliffTranslationImport {
                 this.importTranslationsFromFiles();
             },
         );
-        
+
         context.subscriptions.push(importTranslationsDisposable);
     }
 
@@ -43,14 +43,14 @@ export class XliffTranslationImport {
             canSelectMany: true,
             openLabel: 'Select',
             filters: {
-               'XLIFF Files': ['xlf', 'xlf2']
-           }
-       };
-       window.showOpenDialog(options).then(fileUris => {
+                'XLIFF Files': ['xlf', 'xlf2']
+            }
+        };
+        window.showOpenDialog(options).then(fileUris => {
             if (fileUris) {
                 importTranslationsFromFiles(fileUris);
             }
-       });
+        });
     }
 }
 

--- a/src/features/trans-sync.ts
+++ b/src/features/trans-sync.ts
@@ -64,7 +64,7 @@ export async function createNewTargetFiles() {
     const syncCrossWorkspaceFolders: boolean = workspace.getConfiguration('xliffSync')['syncCrossWorkspaceFolders'];
     if (!syncCrossWorkspaceFolders) {
         workspaceFolder = await window.showWorkspaceFolderPick({
-            placeHolder: 'Select a workspace folder' 
+            placeHolder: 'Select a workspace folder'
         });
         if (!workspaceFolder) {
             throw new Error(`Aborted. You need to select a workspace folder.`);
@@ -87,7 +87,7 @@ export async function createNewTargetFiles() {
 
 /**
  * Synchronize translation files in a workspace.
- * 
+ *
  * @param {boolean} allFiles Whether to sync from the base file to all other files or a single one.
  * @param {WorkspaceFolder} workspaceFolder The workspace folder to restrict the sync to.
  */
@@ -104,7 +104,7 @@ async function synchronizeFilesInWorkspace(allFiles: boolean, workspaceFolder?: 
         else {
             await synchronizeAllFiles(sourceUri, targetUris, workspaceFolder);
         }
-    } 
+    }
     catch (ex) {
         window.showErrorMessage(ex.message);
     }
@@ -113,7 +113,7 @@ async function synchronizeFilesInWorkspace(allFiles: boolean, workspaceFolder?: 
 export async function synchronizeWithSelectedFile(fileUri: Uri) {
     try {
         let workspaceFolder: WorkspaceFolder | undefined;
-        
+
         const syncCrossWorkspaceFolders: boolean = workspace.getConfiguration('xliffSync')['syncCrossWorkspaceFolders'];
         if (!syncCrossWorkspaceFolders) {
             workspaceFolder = workspace.getWorkspaceFolder(fileUri);
@@ -125,7 +125,7 @@ export async function synchronizeWithSelectedFile(fileUri: Uri) {
         let uris: Uri[] = await FilesHelper.getXliffFileUris(workspaceFolder);
 
         let sourceUri: Uri = await FilesHelper.getXliffSourceFile(uris, workspaceFolder);
-        
+
         if (sourceUri.fsPath !== fileUri.fsPath) {
             await synchronizeAndCheckTargetFile(sourceUri, fileUri, undefined, workspaceFolder);
         }
@@ -133,7 +133,7 @@ export async function synchronizeWithSelectedFile(fileUri: Uri) {
             let targetUris = uris.filter((uri) => uri !== sourceUri);
             await synchronizeAllFiles(sourceUri, targetUris, workspaceFolder);
         }
-    } 
+    }
     catch (ex) {
         window.showErrorMessage(ex.message);
     }
@@ -158,14 +158,14 @@ async function synchronizeSingleFile(sourceUri: Uri, targetUris: Uri[], workspac
 
         if (!targetPath) {
             throw new Error('No target file selected');
-        } 
+        }
         else if (targetPath === 'New File...') {
             const fileType: string | undefined = workspace.getConfiguration('xliffSync', workspaceFolder?.uri)['fileType'];
             targetLanguage = await selectNewTargetLanguage(fileType!);
             if (!targetLanguage) {
                 throw new Error('No target language specified');
             }
-        } 
+        }
         else {
             targetUri = targetUris.find((uri) => uri.fsPath === targetPath)!;
         }
@@ -260,7 +260,7 @@ async function synchronizeTargetFile(sourceUri: Uri, targetUri: Uri | undefined,
             if (!newFileContents) {
                 throw new Error(`No ouput generated.`);
             }
-        
+
             targetUri = await FilesHelper.createNewTargetFile(targetUri, newFileContents, sourceUri, targetLanguage);
             const xliffWorkspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('xliffSync', workspaceFolder?.uri);
             const openExternallyAfterEvent: string[] = xliffWorkspaceConfiguration['openExternallyAfterEvent'];
@@ -311,7 +311,7 @@ async function synchronizeAllFiles(sourceUri: Uri, targetUris: Uri[], workspaceF
                 if (matchingOriginalOnly) {
                     targetDocOriginal = targetDoc.original;
                 }
-                
+
                 if (equivalentLanguagesEnabled && targetDoc.targetLanguage) {
                     // Check if master language
                     if (targetDoc.targetLanguage in equivalentLanguages) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,11 @@
     /* Strict Type-Checking Option */
     "strict": true /* enable all strict type-checking options */,
     /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */
+    "noUnusedLocals": true, /* Report errors on unused locals. */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "useUnknownInCatchVariables": false
   },
   "exclude": [
     //        "node_modules",


### PR DESCRIPTION
* New setting `xliffSync.parseFromDeveloperNoteTrimCharacters` that can be used to specify the characters to trim from the translations parsed from the developer notes. (GitHub issue [#100](https://github.com/rvanbekkum/vsc-xliff-sync/issues/100))
* Included `needs-l10n` to be considered as a needs-work state. (GitHub issue [#102](https://github.com/rvanbekkum/vsc-xliff-sync/issues/102))

Updated CHANGELOG accordingly.