### PR TITLE
feat: add ability to define empty tag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ More information: [XLIFF Sync: Time for a complete overview](https://robvanbekku
 | xliffSync.ignoreLineEndingTypeChanges | `false` | Specifies whether changes in line ending type (CRLF vs. LF) should not be considered as changes to the source text of a trans-unit. |
 | xliffSync.clearTranslationAfterSourceTextChange | `false` | Specifies whether translations should be cleared when the source text of a trans-unit changed. |
 | xliffSync.addNeedsWorkTranslationNote | `true` | Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work. |
+| xliffSync.useSelfClosingTags | `true` | Determine how empty XML tags must be handled while generating new XLIFF files (`<note></note>` or `<note/>`). |
 | xliffSync.keepEditorOpenAfterSync | `true` | Specifies whether XLIFF files should be opened in the editor after syncing. |
 | xliffSync.openExternallyAfterEvent | `[]` | Specifies after which event translation files should be opened automatically with the default XLIFF editor. Options: "Check", "ProblemDetected", "Sync" |
 | xliffSync.developerNoteDesignation | `Developer` | Specifies the name that is used to designate a developer note. |

--- a/package.json
+++ b/package.json
@@ -212,6 +212,12 @@
                     "description": "Specifies whether an XLIFF Sync note should be added to explain why a trans-unit was marked as needs-work.",
                     "scope": "resource"
                 },
+                "xliffSync.useSelfClosingTags": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Determine how empty XML tags must be handled while generating new XLIFF files (<note></note> or <note/>).",
+                    "scope": "resource"
+                },
                 "xliffSync.keepEditorOpenAfterSync": {
                     "type": "boolean",
                     "default": true,
@@ -233,8 +239,7 @@
                             "Open automatically after syncing with the base translation file."
                         ]
                     },
-                    "default": [
-                    ],
+                    "default": [],
                     "uniqueItems": true,
                     "description": "Specifies after which event translation files should be opened automatically with the default XLIFF editor",
                     "scope": "resource"

--- a/src/features/tools/xlf/xlf-document.ts
+++ b/src/features/tools/xlf/xlf-document.ts
@@ -172,6 +172,7 @@ export class XlfDocument {
   private missingTranslation: string;
   private needsWorkTranslationSubstate: string;
   private addNeedsWorkTranslationNote: boolean;
+  private useSelfClosingTags: boolean;
 
   private idUnitMap: { [id: string]: XmlNode } | undefined;
   private xliffGeneratorNoteSourceUnitMap: { [key: string]: XmlNode } | undefined;
@@ -196,6 +197,7 @@ export class XlfDocument {
     }
     this.needsWorkTranslationSubstate = xliffWorkspaceConfiguration['needsWorkTranslationSubstate'];
     this.addNeedsWorkTranslationNote = xliffWorkspaceConfiguration['addNeedsWorkTranslationNote'];
+    this.useSelfClosingTags = xliffWorkspaceConfiguration['useSelfClosingTags'];
   }
 
   public static async loadFromUri(sourceUri: Uri, resourceUri: Uri | undefined): Promise<XlfDocument> {
@@ -259,7 +261,7 @@ export class XlfDocument {
     let retVal: string | undefined;
 
     if (this.valid) {
-      retVal = XmlBuilder.create(this.root)!;
+      retVal = XmlBuilder.create(this.root, false, ! this.useSelfClosingTags)!;
 
       const rootIdx = retVal.indexOf('<xliff ');
 

--- a/src/features/tools/xml-builder.ts
+++ b/src/features/tools/xml-builder.ts
@@ -26,7 +26,7 @@ import { create, XMLElementOrXMLNode } from 'xmlbuilder';
 import { XmlNode } from './xml-node';
 
 export class XmlBuilder {
-  public static create(root: XmlNode | undefined, headless: boolean = false): string | undefined {
+  public static create(root: XmlNode | undefined, headless: boolean = false, allowEmpty: boolean = false): string | undefined {
     if (!root) {
       return undefined;
     }
@@ -63,7 +63,7 @@ export class XmlBuilder {
     }
 
     // TODO: pretty as an option ?
-    return outputNode.end();
+    return outputNode.end({ allowEmpty: allowEmpty });
   }
 
   private static appendNode(dest: XMLElementOrXMLNode, source: XmlNode): XMLElementOrXMLNode {


### PR DESCRIPTION
add a new setting called `useSelfClosingTags` which allow to define how empty tag must be write while generating new XLIFF synchronized files.

its default value is `true` meaning empty tag will use self closing format (`<note/>`) - as it was the case prior this change.

when set to `false`, empty tag will be write using opening and closing format (`<note></note>`).

as an example, AL Compiler is using the opening and closing format instead the self-closing one.
using this extension current version with AL project is then generating excessive git diff for small changes since all empty tags are updated to the self-closing format.

references :
- https://github.com/oozcitak/xmlbuilder-js/issues/65
- https://github.com/oozcitak/xmlbuilder-js/wiki#converting-to-string

Closes #97