### PR TITLE
Fix issue #127 Targets are incorrectly marked as needing translation when the translation ends with an x tag

### DIFF
--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -23,22 +23,22 @@
  */
 
 import {
-    commands,
-    DecorationRenderOptions,
-    ExtensionContext,
-    Range,
-    Selection,
-    TextEditor,
-    TextEditorDecorationType,
-    TextEditorRevealType,
-    window,
-    workspace,
-    Uri,
-    WorkspaceConfiguration,
-    WorkspaceFolder
+  commands,
+  DecorationRenderOptions,
+  ExtensionContext,
+  Range,
+  Selection,
+  TextEditor,
+  TextEditorDecorationType,
+  TextEditorRevealType,
+  Uri,
+  window,
+  workspace,
+  WorkspaceConfiguration,
+  WorkspaceFolder
 } from 'vscode';
-import { XlfDocument } from './tools/xlf/xlf-document';
 import { FilesHelper, WorkspaceHelper, XmlNode } from './tools';
+import { XlfDocument } from './tools/xlf/xlf-document';
 import { translationState } from './tools/xlf/xlf-translationState';
 import open = require('open');
 
@@ -243,7 +243,8 @@ export class XliffTranslationChecker {
             'missingTranslation'
         ];
         if (missingTranslationKeyword === '%EMPTY%') {
-            missingTranslationKeyword = '<target[^>]*( state="needs-translation")?[^>]*/>|<target.*( state="needs-translation")?.*></target>';
+            missingTranslationKeyword =
+              '<target[^>]*( state="needs-translation")?[^>]*/>|<target[^>]*( state="needs-translation")?[^>]*></target>';
         }
         else if (decorationTargetTextOnly) {
             missingTranslationKeyword = `(?<=<target.*( state="needs-translation")?.*>)${missingTranslationKeyword}(?=</target>)`;

--- a/src/features/trans-check.ts
+++ b/src/features/trans-check.ts
@@ -247,10 +247,10 @@ export class XliffTranslationChecker {
               '<target[^>]*( state="needs-translation")?[^>]*/>|<target[^>]*( state="needs-translation")?[^>]*></target>';
         }
         else if (decorationTargetTextOnly) {
-            missingTranslationKeyword = `(?<=<target.*( state="needs-translation")?.*>)${missingTranslationKeyword}(?=</target>)`;
+            missingTranslationKeyword = `(?<=<target[^>]*( state="needs-translation")?[^>]*>)${missingTranslationKeyword}(?=</target>)`;
         }
         else {
-            missingTranslationKeyword = `<target.*( state="needs-translation")?.*>${missingTranslationKeyword}</target>`;
+            missingTranslationKeyword = `<target[^>]*( state="needs-translation")?[^>]*>${missingTranslationKeyword}</target>`;
         }
         return missingTranslationKeyword;
     }


### PR DESCRIPTION
This pull request fixes issue #127.

It also fixes related regexes that have the same problem.

## Problem demonstration
Here is the original code:
![image](https://github.com/user-attachments/assets/58e93201-e99f-4ba4-818c-976b6ac9184c)
And here is a regexr.com demonstration of the issue: (regex in 1st if statement case)
![image](https://github.com/user-attachments/assets/ae69894f-1ad3-427b-a54f-8d68ff29cdee)
Here is the fixed regex: (notice the dots being replaced with negated sets)
![image](https://github.com/user-attachments/assets/83b1a439-b20b-43ca-9415-730baf0a162c)

Here is the demonstration of the related code being faulty as well: (2nd and 3rd case, with `missingTranslationKeyword` being set to `EXAMPLE`)
![image](https://github.com/user-attachments/assets/af02f697-4ddb-4d88-9754-fb076fc2a942)

